### PR TITLE
Dynamic charts for Cost Breakdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "style-loader": "0.18.2",
     "sw-precache-webpack-plugin": "0.11.4",
     "url-loader": "0.5.9",
+    "uuid": "^3.2.1",
     "validator": "~9.0.0",
     "webpack": "3.5.1",
     "webpack-dev-server": "2.8.2",
@@ -127,6 +128,9 @@
     ]
   },
   "eslintConfig": {
-    "extends": "react-app"
+    "extends": "react-app",
+    "env": {
+      "jest": true
+    }
   }
 }

--- a/src/actions/aws/costsActions.js
+++ b/src/actions/aws/costsActions.js
@@ -1,27 +1,31 @@
 import Constants from '../../constants';
 
 export default {
-	getCosts: (begin, end, filters) => ({
+	getCosts: (id, begin, end, filters) => ({
 		type: Constants.AWS_GET_COSTS,
+    id,
     begin,
     end,
     filters
 	}),
-  setCostsDates: (startDate, endDate) => ({
+  setCostsDates: (id, startDate, endDate) => ({
     type: Constants.AWS_SET_COSTS_DATES,
+    id,
     dates: {
       startDate,
       endDate
     }
   }),
   clearCostsDates: () => ({type: Constants.AWS_CLEAR_COSTS_DATES}),
-  setCostsInterval: (interval) => ({
+  setCostsInterval: (id, interval) => ({
     type: Constants.AWS_SET_COSTS_INTERVAL,
+    id,
     interval
   }),
   clearCostsInterval: () => ({type: Constants.AWS_CLEAR_COSTS_INTERVAL}),
-  setCostsFilter: (filter) => ({
+  setCostsFilter: (id, filter) => ({
     type: Constants.AWS_SET_COSTS_FILTER,
+    id,
     filter
   }),
   clearCostsFilter: () => ({type: Constants.AWS_CLEAR_COSTS_FILTER}),

--- a/src/containers/aws/CostBreakdownContainer.js
+++ b/src/containers/aws/CostBreakdownContainer.js
@@ -1,85 +1,202 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import UUID from 'uuid/v4';
 import Components from '../../components';
 import Actions from '../../actions';
 import s3square from '../../assets/s3-square.png';
+import moment from "moment/moment";
 
 const TimerangeSelector = Components.Misc.TimerangeSelector;
 const Selector = Components.Misc.Selector;
 const Panel = Components.Misc.Panel;
-const Chart = Components.AWS.CostBreakdown.Chart;
+const CostBreakdownChart = Components.AWS.CostBreakdown.Chart;
 
-export class CostBreakdownContainer extends Component {
+const filters = {
+  all: "Total",
+  account: "Account",
+  product: "Product",
+  region: "Region"
+};
+
+export class Chart extends Component {
+
+  constructor(props) {
+    super(props);
+    this.setDates = this.setDates.bind(this);
+    this.setInterval = this.setInterval.bind(this);
+    this.setFilter = this.setFilter.bind(this);
+    this.close = this.close.bind(this);
+  }
 
   componentWillMount() {
-    this.props.getCosts(this.props.costsDates.startDate, this.props.costsDates.endDate, [this.props.costsFilter, this.props.costsInterval]);
+    this.props.getCosts(this.props.id, this.props.dates.startDate, this.props.dates.endDate, [this.props.filter, this.props.interval]);
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.costsDates !== nextProps.costsDates ||
-      this.props.costsInterval !== nextProps.costsInterval ||
-      this.props.costsFilter !== nextProps.costsFilter ||
+    if (this.props.dates !== nextProps.dates ||
+      this.props.interval !== nextProps.interval ||
+      this.props.filter !== nextProps.filter ||
       this.props.accounts !== nextProps.accounts)
-      nextProps.getCosts(nextProps.costsDates.startDate, nextProps.costsDates.endDate, [nextProps.costsFilter, nextProps.costsInterval]);
+      nextProps.getCosts(nextProps.id, nextProps.dates.startDate, nextProps.dates.endDate, [nextProps.filter, nextProps.interval]);
+  }
+
+  setDates = (start, end) => {
+    this.props.setDates(this.props.id, start, end);
+  };
+
+
+  setInterval = (interval) => {
+    this.props.setInterval(this.props.id, interval);
+  };
+
+
+  setFilter = (filter) => {
+    this.props.setFilter(this.props.id, filter);
+  };
+
+  close = (e) => {
+    e.preventDefault();
+    this.props.close(this.props.id);
+  };
+
+  render() {
+    const close = (this.props.close ? (
+      <button className="btn btn-danger" onClick={this.close}>Remove this chart</button>
+    ) : null);
+    return (
+      <div className="clearfix">
+        <div className="inline-block pull-right">
+          <div className="inline-block">
+            <Selector
+              values={filters}
+              selected={this.props.filter}
+              selectValue={this.setFilter}
+            />
+          </div>
+          <div className="inline-block">
+            <TimerangeSelector
+              startDate={this.props.dates.startDate}
+              endDate={this.props.dates.endDate}
+              setDatesFunc={this.setDates}
+              interval={this.props.interval}
+              setIntervalFunc={this.setInterval}
+            />
+          </div>
+          {close}
+        </div>
+        <CostBreakdownChart values={this.props.values} interval={this.props.interval} filter={this.props.filter}/>
+      </div>
+    );
+  }
+
+}
+
+Chart.propTypes = {
+  id: PropTypes.string.isRequired,
+  values: PropTypes.object,
+  dates: PropTypes.shape({
+    startDate: PropTypes.object,
+    endDate: PropTypes.object,
+  }),
+  accounts: PropTypes.arrayOf(PropTypes.string),
+  interval: PropTypes.string.isRequired,
+  filter: PropTypes.string.isRequired,
+  getCosts: PropTypes.func.isRequired,
+  setDates: PropTypes.func.isRequired,
+  setInterval: PropTypes.func.isRequired,
+  setFilter: PropTypes.func.isRequired,
+  close: PropTypes.func
+};
+
+export class CostBreakdownContainer extends Component {
+
+  constructor(props) {
+    super(props);
+    const firstChart = UUID();
+    this.state = {
+      charts: [
+        firstChart
+      ]
+    };
+    this.initChart(firstChart);
+    this.addChart = this.addChart.bind(this);
+    this.removeChart = this.removeChart.bind(this);
+  }
+
+  addChart = (e) => {
+    e.preventDefault();
+    const newChart = UUID();
+    const charts = [...this.state.charts, newChart];
+    this.initChart(newChart);
+    this.setState({charts});
+  };
+
+  removeChart = (id) => {
+    let charts = this.state.charts;
+    charts.splice(charts.indexOf(id), 1);
+    this.setState({charts});
+  };
+
+  initChart(id) {
+    this.props.setCostsDates(id, moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month'));
+    this.props.setCostsInterval(id, "day");
+    this.props.setCostsFilter(id, filters.product.toLowerCase());
+  }
+
+  getChart(id, index) {
+    if (this.props.costsValues &&
+      this.props.costsDates && this.props.costsDates.hasOwnProperty(id) &&
+      this.props.costsInterval && this.props.costsInterval.hasOwnProperty(id) &&
+      this.props.costsFilter && this.props.costsFilter.hasOwnProperty(id)
+    )
+      return (
+        <Chart
+          key={index}
+          id={id}
+          accounts={this.props.accounts}
+          values={this.props.costsValues[id]}
+          dates={this.props.costsDates[id]}
+          interval={this.props.costsInterval[id]}
+          filter={this.props.costsFilter[id]}
+          getCosts={this.props.getCosts}
+          setDates={this.props.setCostsDates}
+          setInterval={this.props.setCostsInterval}
+          setFilter={this.props.setCostsFilter}
+          close={this.state.charts.length > 1 ? this.removeChart : null}
+        />
+      );
+    return null;
   }
 
   render() {
-
-    const filters = {
-      all: "Total",
-      account: "Account",
-      product: "Product",
-      region: "Region"
-    };
-
-    return(
-      <Panel>
-
-        <div className="clearfix">
-          <h3 className="white-box-title no-padding inline-block">
-            <img className="white-box-title-icon" src={s3square} alt="AWS square logo"/>
-            Cost Breakdown
-          </h3>
-
-          <div className="inline-block pull-right">
-            <div className="inline-block">
-              <Selector
-                values={filters}
-                selected={this.props.costsFilter}
-                selectValue={this.props.setCostsFilter}
-              />
-            </div>
-            <div className="inline-block">
-              <TimerangeSelector
-                startDate={this.props.costsDates.startDate}
-                endDate={this.props.costsDates.endDate}
-                setDatesFunc={this.props.setCostsDates}
-                interval={this.props.costsInterval}
-                setIntervalFunc={this.props.setCostsInterval}
-              />
-            </div>
+    const header = (
+      <div className="clearfix">
+        <h3 className="white-box-title no-padding inline-block">
+          <img className="white-box-title-icon" src={s3square} alt="AWS square logo"/>
+          Cost Breakdown
+        </h3>
+        <div className="inline-block pull-right">
+          <div className="inline-block">
+            <button className="btn btn-default" onClick={this.addChart}>Add a chart</button>
           </div>
-
         </div>
-
-        <div>
-          <Chart values={this.props.costsValues} interval={this.props.costsInterval} filter={this.props.costsFilter}/>
-        </div>
-
-      </Panel>
+      </div>
+    );
+    const charts = this.state.charts.map((id, index) => (this.getChart(id, index)));
+    const children = [header, ...charts];
+    return(
+      <Panel children={children}/>
     );
   }
 }
 
 CostBreakdownContainer.propTypes = {
   costsValues: PropTypes.object,
-  costsDates: PropTypes.shape({
-    startDate: PropTypes.object,
-    endDate: PropTypes.object,
-  }),
-  costsInterval: PropTypes.string.isRequired,
-  costsFilter: PropTypes.string.isRequired,
+  costsDates: PropTypes.object,
+  accounts: PropTypes.arrayOf(PropTypes.string),
+  costsInterval: PropTypes.object.isRequired,
+  costsFilter: PropTypes.object.isRequired,
   getCosts: PropTypes.func.isRequired,
   setCostsDates: PropTypes.func.isRequired,
   setCostsInterval: PropTypes.func.isRequired,
@@ -97,17 +214,17 @@ const mapStateToProps = ({aws}) => ({
 
 /* istanbul ignore next */
 const mapDispatchToProps = (dispatch) => ({
-  getCosts: (begin, end, filters) => {
-    dispatch(Actions.AWS.Costs.getCosts(begin, end, filters));
+  getCosts: (id, begin, end, filters) => {
+    dispatch(Actions.AWS.Costs.getCosts(id, begin, end, filters));
   },
-  setCostsDates: (startDate, endDate) => {
-    dispatch(Actions.AWS.Costs.setCostsDates(startDate, endDate))
+  setCostsDates: (id, startDate, endDate) => {
+    dispatch(Actions.AWS.Costs.setCostsDates(id, startDate, endDate))
   },
-  setCostsInterval: (interval) => {
-    dispatch(Actions.AWS.Costs.setCostsInterval(interval));
+  setCostsInterval: (id, interval) => {
+    dispatch(Actions.AWS.Costs.setCostsInterval(id, interval));
   },
-  setCostsFilter: (filter) => {
-    dispatch(Actions.AWS.Costs.setCostsFilter(filter));
+  setCostsFilter: (id, filter) => {
+    dispatch(Actions.AWS.Costs.setCostsFilter(id, filter));
   }
 });
 

--- a/src/containers/aws/__tests__/CostBreakdownContainer.js
+++ b/src/containers/aws/__tests__/CostBreakdownContainer.js
@@ -1,57 +1,43 @@
 import React from 'react';
-import { CostBreakdownContainer } from '../CostBreakdownContainer';
+import { CostBreakdownContainer, Chart } from '../CostBreakdownContainer';
 import Components from '../../../components';
 import Moment from 'moment';
 import { shallow } from "enzyme";
 
 const TimerangeSelector = Components.Misc.TimerangeSelector;
 const Selector = Components.Misc.Selector;
-const Chart = Components.AWS.CostBreakdown.Chart;
-
-const props = {
-  costsValues: {
-    value: 1,
-    otherValue: 2
-  },
-  costsDates: {
-    startDate: Moment().startOf('month'),
-    endDate: Moment(),
-  },
-  costsInterval: "day",
-  costsFilter: "product",
-  getCosts: jest.fn(),
-  setCostsDates: jest.fn(),
-  setCostsInterval: jest.fn(),
-  setCostsFilter: jest.fn(),
-};
-
-const updatedDateProps = {
-  ...props,
-  costsDates: {
-    startDate: Moment().startOf('year'),
-    endDate: Moment(),
-  },
-  getCosts: jest.fn()
-};
-
-const updatedIntervalProps = {
-  ...props,
-  costsInterval: "month",
-  getCosts: jest.fn()
-};
-
-const updatedFilterProps = {
-  ...props,
-  costsFilter: "region",
-  getCosts: jest.fn()
-};
-
-const propsWithoutCosts = {
-  ...props,
-  costsValues: null
-};
+const CostBreakdownChart = Components.AWS.CostBreakdown.Chart;
 
 describe('<CostBreakdownContainer />', () => {
+
+  const props = {
+    costsValues: {},
+    costsDates: {},
+    costsInterval: {},
+    costsFilter: {},
+    getCosts: jest.fn(),
+    setCostsDates: jest.fn(),
+    setCostsInterval: jest.fn(),
+    setCostsFilter: jest.fn(),
+  };
+
+  const propsAfterMounting = (id) => {
+    let costsDates = {};
+    costsDates[id] = {
+      startDate: Moment().startOf('month'),
+      endDate: Moment().endOf('month'),
+    };
+    let costsInterval = {};
+    costsInterval[id] = "interval";
+    let costsFilter = {};
+    costsFilter[id] = "filter";
+    return {
+      ...props,
+      costsDates,
+      costsInterval,
+      costsFilter
+    }
+  };
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -62,56 +48,184 @@ describe('<CostBreakdownContainer />', () => {
     expect(wrapper.length).toBe(1);
   });
 
-  it('renders <TimerangeSelector/> component', () => {
+  it('renders <Chart/> component', () => {
     const wrapper = shallow(<CostBreakdownContainer {...props}/>);
+    let chart = wrapper.find(Chart);
+    expect(chart.length).toBe(0);
+    const id = wrapper.state("charts")[0];
+    wrapper.setProps(propsAfterMounting(id));
+    chart = wrapper.find(Chart);
+    expect(chart.length).toBe(1);
+  });
+
+  it('can init dates, interval and filter for initial chart when mounting', () => {
+    expect(props.setCostsDates).not.toHaveBeenCalled();
+    expect(props.setCostsInterval).not.toHaveBeenCalled();
+    expect(props.setCostsFilter).not.toHaveBeenCalled();
+    shallow(<CostBreakdownContainer {...props}/>);
+    expect(props.setCostsDates).toHaveBeenCalled();
+    expect(props.setCostsInterval).toHaveBeenCalled();
+    expect(props.setCostsFilter).toHaveBeenCalled();
+  });
+
+  it('can add and remove chart', () => {
+    const wrapper = shallow(<CostBreakdownContainer {...props}/>);
+    const id = wrapper.state("charts")[0];
+    wrapper.setProps(propsAfterMounting(id));
+    expect(props.setCostsDates).toHaveBeenCalledTimes(1);
+    expect(props.setCostsInterval).toHaveBeenCalledTimes(1);
+    expect(props.setCostsFilter).toHaveBeenCalledTimes(1);
+    expect(wrapper.state("charts").length).toBe(1);
+    wrapper.instance().addChart({ preventDefault() {} });
+    expect(props.setCostsDates).toHaveBeenCalledTimes(2);
+    expect(props.setCostsInterval).toHaveBeenCalledTimes(2);
+    expect(props.setCostsFilter).toHaveBeenCalledTimes(2);
+    expect(wrapper.state("charts").length).toBe(2);
+    wrapper.instance().removeChart(id);
+    expect(wrapper.state("charts").length).toBe(1);
+  });
+
+});
+
+describe('<Chart />', () => {
+
+  const props = {
+    id: "42",
+    values: {
+      value: 1,
+      otherValue: 2
+    },
+    dates: {
+      startDate: Moment().startOf('month'),
+      endDate: Moment(),
+    },
+    interval: "day",
+    filter: "product",
+    getCosts: jest.fn(),
+    setDates: jest.fn(),
+    setInterval: jest.fn(),
+    setFilter: jest.fn(),
+  };
+
+  const propsWithClose = {
+    ...props,
+    close: jest.fn()
+  };
+
+  const updatedDateProps = {
+    ...props,
+    dates: {
+      startDate: Moment().startOf('year'),
+      endDate: Moment(),
+    },
+    getCosts: jest.fn()
+  };
+
+  const updatedIntervalProps = {
+    ...props,
+    interval: "month",
+    getCosts: jest.fn()
+  };
+
+  const updatedFilterProps = {
+    ...props,
+    filter: "region",
+    getCosts: jest.fn()
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders a <Chart /> component', () => {
+    const wrapper = shallow(<Chart {...props}/>);
+    expect(wrapper.length).toBe(1);
+  });
+
+  it('renders <TimerangeSelector/> component', () => {
+    const wrapper = shallow(<Chart {...props}/>);
     const timerange = wrapper.find(TimerangeSelector);
     expect(timerange.length).toBe(1);
   });
 
   it('renders <Selector/> component', () => {
-    const wrapper = shallow(<CostBreakdownContainer {...props}/>);
+    const wrapper = shallow(<Chart {...props}/>);
     const selector = wrapper.find(Selector);
     expect(selector.length).toBe(1);
   });
 
-  it('renders <Chart/> component', () => {
-    const wrapper = shallow(<CostBreakdownContainer {...props}/>);
-    const chart = wrapper.find(Chart);
+  it('renders <CostBreakdownChart/> component', () => {
+    const wrapper = shallow(<Chart {...props}/>);
+    const chart = wrapper.find(CostBreakdownChart);
     expect(chart.length).toBe(1);
+  });
+
+  it('renders a <button/> component when can be closed', () => {
+    const wrapper = shallow(<Chart {...propsWithClose}/>);
+    const button = wrapper.find("button");
+    expect(button.length).toBe(1);
   });
 
   it('loads costs when mounting', () => {
     expect(props.getCosts).not.toHaveBeenCalled();
-    shallow(<CostBreakdownContainer {...props}/>);
+    shallow(<Chart {...props}/>);
     expect(props.getCosts).toHaveBeenCalled();
   });
 
   it('reloads costs when dates are updated', () => {
-    const wrapper = shallow(<CostBreakdownContainer {...props}/>);
+    const wrapper = shallow(<Chart {...props}/>);
     expect(updatedDateProps.getCosts).not.toHaveBeenCalled();
     wrapper.instance().componentWillReceiveProps(updatedDateProps);
     expect(updatedDateProps.getCosts).toHaveBeenCalled();
   });
 
   it('reloads costs when interval is updated', () => {
-    const wrapper = shallow(<CostBreakdownContainer {...props}/>);
+    const wrapper = shallow(<Chart {...props}/>);
     expect(updatedIntervalProps.getCosts).not.toHaveBeenCalled();
     wrapper.instance().componentWillReceiveProps(updatedIntervalProps);
     expect(updatedIntervalProps.getCosts).toHaveBeenCalled();
   });
 
   it('reloads costs when filter is updated', () => {
-    const wrapper = shallow(<CostBreakdownContainer {...props}/>);
+    const wrapper = shallow(<Chart {...props}/>);
     expect(updatedFilterProps.getCosts).not.toHaveBeenCalled();
     wrapper.instance().componentWillReceiveProps(updatedFilterProps);
     expect(updatedFilterProps.getCosts).toHaveBeenCalled();
   });
 
   it('does not reload when dates, interval nor filters are updated', () => {
-    const wrapper = shallow(<CostBreakdownContainer {...props}/>);
+    const wrapper = shallow(<Chart {...props}/>);
     expect(props.getCosts).toHaveBeenCalledTimes(1);
     wrapper.instance().componentWillReceiveProps(props);
     expect(props.getCosts).toHaveBeenCalledTimes(1);
+  });
+
+  it('cat set dates', () => {
+    const wrapper = shallow(<Chart {...props}/>);
+    expect(props.setDates).not.toHaveBeenCalled();
+    wrapper.instance().setDates(Moment().startOf('month'), Moment().endOf('month'));
+    expect(props.setDates).toHaveBeenCalledTimes(1);
+  });
+
+  it('cat set filter', () => {
+    const wrapper = shallow(<Chart {...props}/>);
+    expect(props.setFilter).not.toHaveBeenCalled();
+    wrapper.instance().setFilter("filter");
+    expect(props.setFilter).toHaveBeenCalledTimes(1);
+  });
+
+  it('cat set interval', () => {
+    const wrapper = shallow(<Chart {...props}/>);
+    expect(props.setInterval).not.toHaveBeenCalled();
+    wrapper.instance().setInterval("interval");
+    expect(props.setInterval).toHaveBeenCalledTimes(1);
+  });
+
+  it('cat close', () => {
+    const wrapper = shallow(<Chart {...propsWithClose}/>);
+    expect(propsWithClose.close).not.toHaveBeenCalled();
+    wrapper.instance().close({ preventDefault() {} });
+    expect(propsWithClose.close).toHaveBeenCalledTimes(1);
   });
 
 });

--- a/src/containers/aws/__tests__/CostBreakdownContainer.js
+++ b/src/containers/aws/__tests__/CostBreakdownContainer.js
@@ -200,28 +200,28 @@ describe('<Chart />', () => {
     expect(props.getCosts).toHaveBeenCalledTimes(1);
   });
 
-  it('cat set dates', () => {
+  it('can set dates', () => {
     const wrapper = shallow(<Chart {...props}/>);
     expect(props.setDates).not.toHaveBeenCalled();
     wrapper.instance().setDates(Moment().startOf('month'), Moment().endOf('month'));
     expect(props.setDates).toHaveBeenCalledTimes(1);
   });
 
-  it('cat set filter', () => {
+  it('can set filter', () => {
     const wrapper = shallow(<Chart {...props}/>);
     expect(props.setFilter).not.toHaveBeenCalled();
     wrapper.instance().setFilter("filter");
     expect(props.setFilter).toHaveBeenCalledTimes(1);
   });
 
-  it('cat set interval', () => {
+  it('can set interval', () => {
     const wrapper = shallow(<Chart {...props}/>);
     expect(props.setInterval).not.toHaveBeenCalled();
     wrapper.instance().setInterval("interval");
     expect(props.setInterval).toHaveBeenCalledTimes(1);
   });
 
-  it('cat close', () => {
+  it('can close', () => {
     const wrapper = shallow(<Chart {...propsWithClose}/>);
     expect(propsWithClose.close).not.toHaveBeenCalled();
     wrapper.instance().close({ preventDefault() {} });

--- a/src/reducers/aws/accounts/selectionReducer.js
+++ b/src/reducers/aws/accounts/selectionReducer.js
@@ -3,7 +3,7 @@ import Constants from '../../../constants';
 export default (state=[], action) => {
   switch (action.type) {
     case Constants.AWS_SELECT_ACCOUNT:
-      let accounts = state.filter((item) => (item.id !== action.account.id));
+      let accounts = Object.assign([], state).filter((item) => (item.id !== action.account.id));
       if (accounts.length === state.length)
         accounts.push(action.account);
       return accounts;

--- a/src/reducers/aws/costs/__tests__/datesReducer.js
+++ b/src/reducers/aws/costs/__tests__/datesReducer.js
@@ -1,35 +1,27 @@
 import DatesReducer from '../datesReducer';
 import Constants from '../../../../constants';
-import moment from 'moment';
 
 describe("DatesReducer", () => {
 
+  const id = "id";
+  const dates = "dates";
+  let state = {};
+  state[id] = dates;
+
   it("handles initial state", () => {
-    expect(DatesReducer(undefined, {})).toEqual(null);
+    expect(DatesReducer(undefined, {})).toEqual({});
   });
 
   it("handles set dates state", () => {
-    const dates = {
-      startDate: moment().startOf('month'),
-      endDate: moment()
-    };
-    expect(DatesReducer(null, { type: Constants.AWS_SET_COSTS_DATES, dates })).toEqual(dates);
+    expect(DatesReducer({}, { type: Constants.AWS_SET_COSTS_DATES, id, dates })).toEqual(state);
   });
 
   it("handles clear dates state", () => {
-    const dates = {
-      startDate: moment().startOf('month'),
-      endDate: moment()
-    };
-    expect(DatesReducer(dates, { type: Constants.AWS_CLEAR_COSTS_DATES })).toEqual(null);
+    expect(DatesReducer(state, { type: Constants.AWS_CLEAR_COSTS_DATES })).toEqual({});
   });
 
   it("handles wrong type state", () => {
-    const dates = {
-      startDate: moment().startOf('month'),
-      endDate: moment()
-    };
-    expect(DatesReducer(dates, { type: "" })).toEqual(dates);
+    expect(DatesReducer(state, { type: "" })).toEqual(state);
   });
 
 });

--- a/src/reducers/aws/costs/__tests__/filterReducer.js
+++ b/src/reducers/aws/costs/__tests__/filterReducer.js
@@ -3,23 +3,25 @@ import Constants from '../../../../constants';
 
 describe("FilterReducer", () => {
 
+  const id = "id";
+  const filter = "filter";
+  let state = {};
+  state[id] = filter;
+
   it("handles initial state", () => {
-    expect(FilterReducer(undefined, {})).toEqual(null);
+    expect(FilterReducer(undefined, {})).toEqual({});
   });
 
   it("handles set filter state", () => {
-    const filter = "filter";
-    expect(FilterReducer(null, { type: Constants.AWS_SET_COSTS_FILTER, filter })).toEqual(filter);
+    expect(FilterReducer({}, { type: Constants.AWS_SET_COSTS_FILTER, id, filter })).toEqual(state);
   });
 
   it("handles clear filter state", () => {
-    const filter = "filter";
-    expect(FilterReducer(filter, { type: Constants.AWS_CLEAR_COSTS_FILTER })).toEqual(null);
+    expect(FilterReducer(state, { type: Constants.AWS_CLEAR_COSTS_FILTER })).toEqual({});
   });
 
   it("handles wrong type state", () => {
-    const filter = "filter";
-    expect(FilterReducer(filter, { type: "" })).toEqual(filter);
+    expect(FilterReducer(state, { type: "" })).toEqual(state);
   });
 
 });

--- a/src/reducers/aws/costs/__tests__/intervalReducer.js
+++ b/src/reducers/aws/costs/__tests__/intervalReducer.js
@@ -3,23 +3,25 @@ import Constants from '../../../../constants';
 
 describe("IntervalReducer", () => {
 
+  const id = "id";
+  const interval = "interval";
+  let state = {};
+  state[id] = interval;
+
   it("handles initial state", () => {
-    expect(IntervalReducer(undefined, {})).toEqual(null);
+    expect(IntervalReducer(undefined, {})).toEqual({});
   });
 
   it("handles set interval state", () => {
-    const interval = "interval";
-    expect(IntervalReducer(null, { type: Constants.AWS_SET_COSTS_INTERVAL, interval })).toEqual(interval);
+    expect(IntervalReducer({}, { type: Constants.AWS_SET_COSTS_INTERVAL, id, interval })).toEqual(state);
   });
 
   it("handles clear interval state", () => {
-    const interval = "interval";
-    expect(IntervalReducer(interval, { type: Constants.AWS_CLEAR_COSTS_INTERVAL })).toEqual(null);
+    expect(IntervalReducer(state, { type: Constants.AWS_CLEAR_COSTS_INTERVAL })).toEqual({});
   });
 
   it("handles wrong type state", () => {
-    const interval = "interval";
-    expect(IntervalReducer(interval, { type: "" })).toEqual(interval);
+    expect(IntervalReducer(state, { type: "" })).toEqual(state);
   });
 
 });

--- a/src/reducers/aws/costs/__tests__/valuesReducer.js
+++ b/src/reducers/aws/costs/__tests__/valuesReducer.js
@@ -3,28 +3,25 @@ import Constants from '../../../../constants';
 
 describe("ValuesReducer", () => {
 
+  const id = "id";
+  const costs = "costs";
+  let state = {};
+  state[id] = costs;
+
   it("handles initial state", () => {
-    expect(ValuesReducer(undefined, {})).toEqual(null);
+    expect(ValuesReducer(undefined, {})).toEqual({});
   });
 
   it("handles set values state", () => {
-    const costs = { cost: 0, anotherCost: 1 };
-    expect(ValuesReducer(null, { type: Constants.AWS_GET_COSTS_SUCCESS, costs })).toEqual(costs);
-  });
-
-  it("handles request values state", () => {
-    const costs = { cost: 0, anotherCost: 1 };
-    expect(ValuesReducer(costs, { type: Constants.AWS_GET_COSTS })).toEqual(null);
+    expect(ValuesReducer({}, { type: Constants.AWS_GET_COSTS_SUCCESS, id, costs })).toEqual(state);
   });
 
   it("handles error with values state", () => {
-    const costs = { cost: 0, anotherCost: 1 };
-    expect(ValuesReducer(costs, { type: Constants.AWS_GET_COSTS_ERROR })).toEqual(null);
+    expect(ValuesReducer(state, { type: Constants.AWS_GET_COSTS_ERROR })).toEqual({});
   });
 
   it("handles wrong type state", () => {
-    const costs = { cost: 0, anotherCost: 1 };
-    expect(ValuesReducer(costs, { type: "" })).toEqual(costs);
+    expect(ValuesReducer(state, { type: "" })).toEqual(state);
   });
 
 });

--- a/src/reducers/aws/costs/datesReducer.js
+++ b/src/reducers/aws/costs/datesReducer.js
@@ -1,11 +1,13 @@
 import Constants from '../../../constants';
 
-export default (state=null, action) => {
+export default (state={}, action) => {
   switch (action.type) {
     case Constants.AWS_CLEAR_COSTS_DATES:
-      return null;
+      return {};
     case Constants.AWS_SET_COSTS_DATES:
-    return action.dates;
+      let dates = Object.assign({}, state);
+      dates[action.id] = action.dates;
+      return dates;
     default:
       return state;
   }

--- a/src/reducers/aws/costs/filterReducer.js
+++ b/src/reducers/aws/costs/filterReducer.js
@@ -1,11 +1,13 @@
 import Constants from '../../../constants';
 
-export default (state=null, action) => {
+export default (state={}, action) => {
   switch (action.type) {
     case Constants.AWS_CLEAR_COSTS_FILTER:
-      return null;
+      return {};
     case Constants.AWS_SET_COSTS_FILTER:
-    return action.filter;
+      let filters = Object.assign({}, state);
+      filters[action.id] = action.filter;
+    return filters;
     default:
       return state;
   }

--- a/src/reducers/aws/costs/intervalReducer.js
+++ b/src/reducers/aws/costs/intervalReducer.js
@@ -1,11 +1,13 @@
 import Constants from '../../../constants';
 
-export default (state=null, action) => {
+export default (state={}, action) => {
   switch (action.type) {
     case Constants.AWS_CLEAR_COSTS_INTERVAL:
-      return null;
+      return {};
     case Constants.AWS_SET_COSTS_INTERVAL:
-    return action.interval;
+      let intervals = Object.assign({}, state);
+      intervals[action.id] = action.interval;
+      return intervals;
     default:
       return state;
   }

--- a/src/reducers/aws/costs/valuesReducer.js
+++ b/src/reducers/aws/costs/valuesReducer.js
@@ -1,12 +1,13 @@
 import Constants from '../../../constants';
 
-export default (state=null, action) => {
+export default (state={}, action) => {
   switch (action.type) {
-    case Constants.AWS_GET_COSTS:
     case Constants.AWS_GET_COSTS_ERROR:
-      return null;
+      return {};
     case Constants.AWS_GET_COSTS_SUCCESS:
-    return action.costs;
+      let costs = Object.assign({}, state);
+      costs[action.id] = action.costs;
+      return costs;
     default:
       return state;
   }

--- a/src/sagas/aws/costsSaga.js
+++ b/src/sagas/aws/costsSaga.js
@@ -3,13 +3,13 @@ import { getToken, getAWSAccounts } from '../misc';
 import API from '../../api';
 import Constants from '../../constants';
 
-export function* getCostsSaga({ begin, end, filters }) {
+export function* getCostsSaga({ id, begin, end, filters }) {
   try {
     const token = yield getToken();
     const accounts = yield getAWSAccounts();
     const res = yield call(API.AWS.Costs.getCosts, token, begin, end, filters, accounts);
     if (res.success && res.hasOwnProperty("data"))
-      yield put({ type: Constants.AWS_GET_COSTS_SUCCESS, costs: res.data });
+      yield put({ type: Constants.AWS_GET_COSTS_SUCCESS, id, costs: res.data });
     else
       throw Error("Error with request");
   } catch (error) {

--- a/src/sagas/aws/index.js
+++ b/src/sagas/aws/index.js
@@ -1,4 +1,4 @@
-import { takeLatest } from 'redux-saga/effects';
+import { takeEvery, takeLatest } from 'redux-saga/effects';
 import * as AccountsSaga from './accountsSaga';
 import { getCostsSaga } from "./costsSaga";
 import { getS3DataSaga } from './s3Saga';
@@ -46,5 +46,5 @@ export function* watchGetAwsS3Data() {
 }
 
 export function* watchGetCosts() {
-  yield takeLatest(Constants.AWS_GET_COSTS, getCostsSaga);
+  yield takeEvery(Constants.AWS_GET_COSTS, getCostsSaga);
 }

--- a/src/store/initialState.js
+++ b/src/store/initialState.js
@@ -13,13 +13,10 @@ export default {
       }
     },
     costs: {
-      values: null,
-      dates: {
-        startDate: moment().subtract(1, 'month').startOf('month'),
-        endDate: moment().subtract(1, 'month').endOf('month')
-      },
-      interval: "day",
-      filter: "product"
+      values: {},
+      dates: {},
+      interval: {},
+      filter: {}
     }
   },
   gcp: {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,10 +6,6 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.1.0.tgz#93b1be91f63c184450385272c47b6496fd028e02"
 
-"@types/jss@^9.3.0":
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/@types/jss/-/jss-9.3.0.tgz#0f8484fd03ded206917be27b58217f274a0ad59f"
-
 "@types/node@*":
   version "8.0.54"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.54.tgz#3fd9357db4af388b79e03845340259440edffde6"
@@ -1780,12 +1776,6 @@ css-selector-tokenizer@^0.7.0:
 css-vendor@^0.3.8:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-0.3.8.tgz#6421cfd3034ce664fe7673972fd0119fc28941fa"
-  dependencies:
-    is-in-browser "^1.0.2"
-
-css-vendor@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-1.0.0.tgz#7d8883f781981d9fd6d7630b7fc5ff3a23157347"
   dependencies:
     is-in-browser "^1.0.2"
 
@@ -4236,12 +4226,6 @@ jss-vendor-prefixer@^7.0.0:
   dependencies:
     css-vendor "^0.3.8"
 
-jss-vendor-prefixer@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/jss-vendor-prefixer/-/jss-vendor-prefixer-8.0.0.tgz#5ce6275bf63c1af2a0b7164c3ecdb68dd7bb1d22"
-  dependencies:
-    css-vendor "^1.0.0"
-
 jss@^9.3.2, jss@^9.3.3:
   version "9.5.1"
   resolved "https://registry.yarnpkg.com/jss/-/jss-9.5.1.tgz#c869f38cdc44a32f4425fe007ea46b8891536326"
@@ -4523,11 +4507,10 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-material-ui@1.0.0-beta.28:
-  version "1.0.0-beta.28"
-  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-1.0.0-beta.28.tgz#dd78553ea2de2b028699fe9dad4c880a2e10f670"
+material-ui@1.0.0-beta.27:
+  version "1.0.0-beta.27"
+  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-1.0.0-beta.27.tgz#f3073b7acffebd1fc6d0339a3260d4555445daf7"
   dependencies:
-    "@types/jss" "^9.3.0"
     babel-runtime "^6.26.0"
     brcast "^3.0.1"
     classnames "^2.2.5"
@@ -4540,7 +4523,7 @@ material-ui@1.0.0-beta.28:
     jss-global "^3.0.0"
     jss-nested "^6.0.1"
     jss-props-sort "^6.0.0"
-    jss-vendor-prefixer "^8.0.0"
+    jss-vendor-prefixer "^7.0.0"
     keycode "^2.1.9"
     lodash "^4.2.0"
     normalize-scroll-left "^0.1.2"
@@ -7129,6 +7112,10 @@ uuid@^2.0.1, uuid@^2.0.2:
 uuid@^3.0.0, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
+uuid@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
I added support for multiple charts in Cost Breakdown Container.
You will be able to add charts and change filters, dates, intervals easily to compare charts.

![trackit2-multiple_cost_breakdown](https://user-images.githubusercontent.com/1793678/35056570-835d1d7e-fbb2-11e7-968f-c124e63adaf0.png)
