### PR TITLE
Add status badges for each AWS accounts on every view

### DIFF
--- a/src/components/aws/accounts/StatusBadgesComponent.js
+++ b/src/components/aws/accounts/StatusBadgesComponent.js
@@ -1,0 +1,142 @@
+import React, {Component} from 'react';
+import { connect } from 'react-redux';
+import { OverlayTrigger, Popover } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+
+const fontAwesomeCodeCheck = 'circle';
+const fontAwesomeCodeMiddle = 'times-circle';
+const fontAwesomeCodeTimes = 'times-circle';
+const greenClass = 'green-color';
+const orangeClass = 'orange-color';
+const redClass = 'red-color';
+
+const isObjectEmpty = (obj) => (Object.keys(obj).length === 0 && obj.constructor === Object);
+
+export class StatusBadgeComponent extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {};
+    }
+
+    // Determine Item warning level : 0 no warnings, 1 warning, 2 error
+    getItemWarningLevel(item) {
+        if (item.billRepositories.length) {
+            let hasError = false;
+            for (let i = 0; i < item.billRepositories.length; i++) {
+                const element = item.billRepositories[i];
+                if (element.error.length) {
+                    hasError = true;
+                }
+            }
+
+            if (!hasError) { // Bills locations are working
+                if  (isObjectEmpty(this.props.values)) { // But there is no data
+                    return 1;
+                }
+                return 0;
+            }
+            return 2;
+        }  
+        // No bill locations for account
+        return 2;
+    }
+
+    getItemClasses(item) {
+        const classes = [
+            `fa fa-${fontAwesomeCodeCheck} ${greenClass}`,
+            `fa fa-${fontAwesomeCodeMiddle} ${orangeClass}`,
+            `fa fa-${fontAwesomeCodeTimes} ${redClass}`
+        ];
+        return classes[this.getItemWarningLevel(item)];
+    }
+
+    getItemPopover(item) {
+        const okText = (
+            <div>
+                <i className="fa fa-check green-color"/>
+                &nbsp;
+                This AWS account is properly set up and returns data.
+            </div>
+        );
+        const middleText = (
+            <div>
+                <i className="fa fa-times orange-color"/>
+                &nbsp;
+                This AWS account is properly set up but <strong>TrackIt</strong> does not have data for the selected Timerange.
+                <hr />
+                Please select another timerange or wait for data to be imported.
+                <hr />
+                For more details please check the Status of your account on the <strong>Setup page</strong>.
+            </div>
+        );
+        const badText = (
+            <div>
+                <i className="fa fa-times red-color"/>
+                &nbsp;
+                This AWS account is not set up properly. <strong>TrackIt</strong> could not access the billing data in the specified S3 bucket.
+                <hr />
+                Please check the Status of your account on the <strong>Setup page</strong>.
+            </div>
+        );
+
+        let text = [okText, middleText, badText];
+        
+        return (
+            <Popover id={`popover-trigger-${item.pretty}`} title={`${item.pretty} AWS Account`}>
+                {text[this.getItemWarningLevel(item)]}
+            </Popover>
+        );
+    }
+
+    getItemBadge(item) {          
+        return(
+            <span className="account-status-badge" key={item.pretty}>
+                <OverlayTrigger
+                trigger={['hover', 'focus']}
+                placement="bottom"
+                overlay={this.getItemPopover(item)}
+                >
+                    <i 
+                        className={this.getItemClasses(item)}
+                    />
+                </OverlayTrigger>
+            </span>
+        );
+    }
+
+    render() {
+        const { accounts, selected } = this.props;
+
+        let badges;
+        // Some accounts are selected
+        if (selected.length) {
+            badges = selected.map(item => this.getItemBadge(item));
+        } else { // No selected accounts, displaying all accounts
+            if (accounts.status && accounts.values) {
+                badges = accounts.values.map(item => this.getItemBadge(item));
+            }
+        }
+
+        return (
+            <span className="m-l-10">
+                {badges}
+            </span>
+        );
+    }
+}
+
+StatusBadgeComponent.propTypes = {
+    values: PropTypes.object.isRequired,
+};
+
+/* istanbul ignore next */
+const mapStateToProps = ({aws}) => ({
+  accounts: aws.accounts.all,
+  selected: aws.accounts.selection,
+});
+
+/* istanbul ignore next */
+const mapDispatchToProps = (dispatch) => ({
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(StatusBadgeComponent);

--- a/src/components/aws/accounts/__tests__/StatusBadgesComponent.js
+++ b/src/components/aws/accounts/__tests__/StatusBadgesComponent.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import { StatusBadgeComponent } from '../StatusBadgesComponent';
+import {
+    shallow,
+} from 'enzyme';
+
+const account1 = {
+    id: 42,
+    roleArn: "arn:aws:iam::000000000000:role/TEST_ROLE",
+    pretty: "pretty",
+    billRepositories: [{
+        awsAccountId: 1,
+        bucket: "trackit-billing-report",
+        error: "",
+        id: 4,
+        lastImportedManifest: "2018-08-01T13:12:25Z",
+        nextPending: false,
+        nextUpdate: "2018-08-02T16:12:26Z",
+        prefix: "usagecost/AllHourlyToS3/"
+    }]
+};
+
+const account2 = {
+    id: 84,
+    roleArn: "arn:aws:iam::000000000000:role/TEST_ROLE_BIS",
+    pretty: "pretty_bis",
+    billRepositories: [{
+        awsAccountId: 1,
+        bucket: "trackit-billing-report",
+        error: "this is an error",
+        id: 4,
+        lastImportedManifest: "2018-08-01T13:12:25Z",
+        nextPending: false,
+        nextUpdate: "2018-08-02T16:12:26Z",
+        prefix: "usagecost/AllHourlyToS3/"
+    }]
+};
+
+describe('<StatusBadgeComponent />', () => {
+
+    const propsNoSelectionWithValues = {
+        accounts: {
+            status: true,
+            values: [account1, account2],
+        },
+        selected: [],
+        values: { value: true }
+    };
+    const propsNoSelectionWithoutValues = {
+        accounts: {
+            status: true,
+            values: [account1, account2],
+        },
+        selected: [],
+        values: {}
+    };
+    const propsSelectionWithValues = {
+        accounts: {
+            status: true,
+            values: [account1, account2],
+        },
+        selected: [account1],
+        values: { value: true }
+    };
+
+    it('renders a <StatusBadges /> component', () => {
+        const wrapper = shallow(<StatusBadgeComponent {...propsNoSelectionWithValues}/>);
+        expect(wrapper.length).toBe(1);
+    });
+
+
+    it('renders a badge for each account', () => {
+        const wrapper = shallow(<StatusBadgeComponent {...propsNoSelectionWithValues}/>);
+        const badges = wrapper.find('span.account-status-badge');
+        expect(badges.length).toBe(2);
+    });
+
+    it('renders account badges colors properly', () => {
+        const wrapperValues = shallow(<StatusBadgeComponent {...propsNoSelectionWithValues}/>);
+        const wrapperNoValues = shallow(<StatusBadgeComponent {...propsNoSelectionWithoutValues}/>);
+
+        expect(wrapperValues.find('.green-color').length).toBe(1);
+        expect(wrapperValues.find('.red-color').length).toBe(1);
+        expect(wrapperNoValues.find('.orange-color').length).toBe(1);
+        expect(wrapperNoValues.find('.red-color').length).toBe(1);
+    });
+
+    it('renders selection when a selection is set', () => {
+        const wrapper = shallow(<StatusBadgeComponent {...propsSelectionWithValues}/>);
+        const badges = wrapper.find('span.account-status-badge');
+        expect(badges.length).toBe(1);
+    }); 
+});

--- a/src/components/aws/accounts/index.js
+++ b/src/components/aws/accounts/index.js
@@ -5,6 +5,7 @@ import SingleAccountSelector from './ReportAccountSelectorComponent';
 import Bills from './bills';
 import Wizard from './WizardComponent';
 import SelectedIndicator from './SelectedIndicatorComponent';
+import StatusBadges from './StatusBadgesComponent';
 
 export default {
   Form,
@@ -13,5 +14,6 @@ export default {
   SingleAccountSelector,
   Bills,
   SelectedIndicator,
-  Wizard
+  Wizard,
+  StatusBadges
 };

--- a/src/components/aws/costBreakdown/ChartComponent.js
+++ b/src/components/aws/costBreakdown/ChartComponent.js
@@ -4,6 +4,7 @@ import Spinner from 'react-spinkit';
 import BarChart from './BarChartComponent';
 import PieChart from './PieChartComponent';
 import DifferentiatorChart from './DifferentiatorChartComponent';
+import AWSAccounts from '../../aws/accounts';
 import Misc from '../../misc';
 import Moment from "moment/moment";
 
@@ -104,6 +105,21 @@ export class Header extends Component {
   getIcon() {
     if (!this.props.icon)
       return null;
+
+    let badges;
+
+    if (this.props.values && this.props.values.status) {
+      badges = (
+        <AWSAccounts.StatusBadges
+          values={
+            this.props.values ? (
+              this.props.values.status ? this.props.values.values : {}
+            ) : {}
+          }
+        />
+      );
+    }
+
     switch (this.props.type) {
       case "pie":
         return (
@@ -111,6 +127,7 @@ export class Header extends Component {
             <i className="menu-icon red-color fa fa-pie-chart"/>
             &nbsp;
             Pie Chart
+            {badges}
           </div>
         );
       case "diff":
@@ -119,6 +136,7 @@ export class Header extends Component {
             <i className="menu-icon red-color fa fa-table"/>
             &nbsp;
             Cost Table
+            {badges}
           </div>
         );
       case "bar":
@@ -128,6 +146,7 @@ export class Header extends Component {
             <i className="menu-icon red-color fa fa-bar-chart"/>
             &nbsp;
             Bar Chart
+            {badges}
           </div>
         );
     }

--- a/src/components/dashboard/DashboardComponent.js
+++ b/src/components/dashboard/DashboardComponent.js
@@ -6,6 +6,7 @@ import UUID from 'uuid/v4';
 import Actions from '../../actions';
 import AWS from './aws';
 import Misc from '../misc';
+import AWSAccounts from '../aws/accounts'
 
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
@@ -56,6 +57,20 @@ const generateLayout = (item) => {
 const renderItem = (key, item, child, close=null) => {
   const layout = generateLayout(item);
   let title;
+  let badges;
+
+  if (child && child.props && child.props.values && child.props.values.status) {
+    badges = (
+      <AWSAccounts.StatusBadges
+        values={
+          child.props.values ? (
+            child.props.values.status ? child.props.values.values : {}
+          ) : {}
+        }
+      />
+    );
+  }
+
   switch (item.type) {
     case "cb_infos":
     case "cb_pie":
@@ -65,6 +80,7 @@ const renderItem = (key, item, child, close=null) => {
           <i className="menu-icon fa fa-area-chart red-color"/>
           &nbsp;
           Cost Breakdown
+          {badges}
         </div>
       );
       break;
@@ -75,6 +91,7 @@ const renderItem = (key, item, child, close=null) => {
           <img className="white-box-title-icon" src={s3square} alt="AWS square logo"/>
           &nbsp;
           S3 Analytics
+          {badges}
         </div>
       );
       break;

--- a/src/containers/aws/ResourcesMapContainer.js
+++ b/src/containers/aws/ResourcesMapContainer.js
@@ -230,6 +230,21 @@ export class ResourcesMapContainer extends Component {
       </div>
     ));
 
+    let badges;
+
+    if (this.props.costs && this.props.costs.status) {
+      badges = (
+        <Components.AWS.Accounts.StatusBadges
+          values={
+            this.props.costs ? (
+              this.props.costs.status ? this.props.costs.values : {}
+            ) : {}
+          }
+        />
+      );
+    }
+  
+
     return (
       <div className="container-fluid">
 
@@ -238,6 +253,7 @@ export class ResourcesMapContainer extends Component {
             <h3 className="white-box-title no-padding inline-block">
               <img className="white-box-title-icon" src={s3square} alt="AWS square logo"/>
               Resources Map
+              {badges}
             </h3>
           </div>
           <div className="inline-block pull-right">

--- a/src/containers/aws/S3AnalyticsContainer.js
+++ b/src/containers/aws/S3AnalyticsContainer.js
@@ -42,6 +42,21 @@ export class S3AnalyticsContainer extends Component {
       />
     ) : null);
 
+    let badges;
+
+    if (this.props.values && this.props.values.status) {
+      badges = (
+        <Components.AWS.Accounts.StatusBadges
+          values={
+            this.props.values ? (
+              this.props.values.status ? this.props.values.values : {}
+            ) : {}
+          }
+        />
+      );
+    }
+  
+
     return (
       <Panel>
 
@@ -49,6 +64,7 @@ export class S3AnalyticsContainer extends Component {
           <h3 className="white-box-title no-padding inline-block">
             <img className="white-box-title-icon" src={s3square} alt="AWS square logo"/>
             AWS S3 Analytics
+            {badges}
           </h3>
           <div className="inline-block pull-right">
             {timerange}

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -20,6 +20,14 @@ body {
   font-weight: 400;
 }
 
+.account-status-badge {
+    margin: 2px;
+}
+
+.account-status-badge i {
+    font-size: 12px !important;
+}
+
 .card-label {
   color: #808080;
   font-weight: 300;
@@ -47,6 +55,15 @@ body {
 
 .font-light {
   font-weight: 300 !important;
+}
+
+.popover {
+    border-radius: 0px;
+}
+
+.popover-title {
+    background-color: white;
+    color: black;
 }
 
 select {


### PR DESCRIPTION
This adds some status badges for each account on each UI panel / views.
The badge would be: 

- Red if the account is not setup properly
- Orange if the account is setup properly but has no data for the specific panel
- Green if everything works

Hovering the badges will give the user more details.

![screen shot 2018-08-01 at 17 23 10](https://user-images.githubusercontent.com/3480526/43594243-13c1a60c-967a-11e8-83fc-cb6ee8b6a07a.png)
![screen shot 2018-08-01 at 17 16 18](https://user-images.githubusercontent.com/3480526/43594284-28f1e67c-967a-11e8-9284-c2aabad05e66.png)
![screen shot 2018-08-01 at 17 15 41](https://user-images.githubusercontent.com/3480526/43594285-293531d4-967a-11e8-9244-8a16c070eb8e.png)
![screen shot 2018-08-01 at 17 15 36](https://user-images.githubusercontent.com/3480526/43594286-29846d80-967a-11e8-92b5-e6617db662f9.png)
![screen shot 2018-08-01 at 17 16 34](https://user-images.githubusercontent.com/3480526/43594308-3571b4ea-967a-11e8-89a1-bf271966d3c9.png)
