### PR TITLE
Auto logout when token expired

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,9 +68,8 @@ jobs:
       - run:
           environment:
             CI: 'false'
-            API_URL: $API_URL_STG
           name: Building
-          command: npm run build
+          command: API_URL=$API_URL_STG npm run build
       - deploy:
           name: Deploying
           command: aws s3 sync --delete build/ $S3_DEPLOYMENT_DESTINATION_STG

--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,7 @@ export class App extends Component {
 
   render() {
 
-    const redirectToLogin = () => <Redirect to={`${this.props.match.url}/login/timeout`}/>;
+    const redirectToLogin = () => <Redirect to="/login/timeout"/>;
     const redirectToSetup = () => <Redirect to={`${this.props.match.url}/setup/false`}/>;
     const hasAccounts = (this.props.accounts.status ? (this.props.accounts.hasOwnProperty("values") && this.props.accounts.values && this.props.accounts.values.length > 0 ): true);
 

--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,7 @@ export class App extends Component {
 
   render() {
 
-    const redirectToLogin = () => <Redirect to={`${this.props.match.url}/login`}/>;
+    const redirectToLogin = () => <Redirect to={`${this.props.match.url}/login/timeout`}/>;
     const redirectToSetup = () => <Redirect to={`${this.props.match.url}/setup/false`}/>;
     const hasAccounts = (this.props.accounts.status ? (this.props.accounts.hasOwnProperty("values") && this.props.accounts.values && this.props.accounts.values.length > 0 ): true);
 

--- a/src/App.js
+++ b/src/App.js
@@ -15,8 +15,11 @@ export class App extends Component {
 
   render() {
 
+    const redirectToLogin = () => <Redirect to={`${this.props.match.url}/login`}/>;
     const redirectToSetup = () => <Redirect to={`${this.props.match.url}/setup/false`}/>;
     const hasAccounts = (this.props.accounts.status ? (this.props.accounts.hasOwnProperty("values") && this.props.accounts.values && this.props.accounts.values.length > 0 ): true);
+
+    const checkRedirections = (container) => (!this.props.token ? redirectToLogin : (hasAccounts ? container : redirectToSetup));
 
     return (
       <div>
@@ -24,27 +27,27 @@ export class App extends Component {
           <div className="app-container">
             <Route
               path={this.props.match.url} exact
-              component={hasAccounts ? Containers.Home : redirectToSetup}
+              component={checkRedirections(Containers.Home)}
             />
             <Route
               path={this.props.match.url + '/s3'}
-              component={hasAccounts ? Containers.AWS.S3Analytics : redirectToSetup}
+              component={checkRedirections(Containers.AWS.S3Analytics)}
             />
             <Route
               path={this.props.match.url + '/costbreakdown'}
-              component={hasAccounts ? Containers.AWS.CostBreakdown : redirectToSetup}
+              component={checkRedirections(Containers.AWS.CostBreakdown)}
             />
             <Route
               path={this.props.match.url + '/reports'}
-              component={hasAccounts ? Containers.AWS.Reports : redirectToSetup}
+              component={checkRedirections(Containers.AWS.Reports)}
             />
             <Route
               path={this.props.match.url + "/map"}
-              component={hasAccounts ? Containers.AWS.ResourcesMap : redirectToSetup}
+              component={checkRedirections(Containers.AWS.ResourcesMap)}
             />
             <Route
               path={this.props.match.url + "/setup/:hasAccounts*"}
-              component={Containers.Setup.Main}
+              component={this.props.token ? Containers.Setup.Main : redirectToLogin}
             />
           </div>
         </Containers.Main>
@@ -71,12 +74,14 @@ App.propTypes = {
       })
     ),
   }),
-  getAccounts: PropTypes.func.isRequired
+  getAccounts: PropTypes.func.isRequired,
+  token: PropTypes.string
 };
 
 /* istanbul ignore next */
-const mapStateToProps = ({aws}) => ({
+const mapStateToProps = ({aws, auth}) => ({
   accounts: aws.accounts.all,
+  token: auth.token
 });
 
 /* istanbul ignore next */

--- a/src/api/misc.js
+++ b/src/api/misc.js
@@ -1,5 +1,11 @@
 import Config from '../config';
 
+const handleResponse = (response) => {
+  if (response.status === 401)
+    throw response.statusText;
+  return response.json();
+};
+
 export const call = (route, method, body=null, token=null) => {
   let headers = {
     'Content-Type': 'application/json',
@@ -11,9 +17,10 @@ export const call = (route, method, body=null, token=null) => {
     method,
     headers,
     body: (body !== null ? JSON.stringify(body) : null)
-  }).then(data => (data.json()))
+  }).then(handleResponse)
     .then(response => ({success: true, data: response }))
-    .then(error => ({success: false, ...error}));
+    .then(error => ({success: false, ...error}))
+    .catch(error => ({success: null, error}));
 };
 
 export const download = (route, method='GET', body=null, token=null, contentType='text/csv') => {

--- a/src/components/auth/FormComponent.js
+++ b/src/components/auth/FormComponent.js
@@ -163,6 +163,10 @@ export class FormComponent extends Component {
       </div>;
     }
 
+    const timeout = (this.props.timeout ? (
+      <div className="alert alert-warning">Your session expired. Please log in again.</div>
+    ) : null);
+
     return (
       <div className="login">
         <div className="row">
@@ -179,9 +183,8 @@ export class FormComponent extends Component {
               </h3>
 
               {error}
+              {timeout}
               {success}
-
-
 
               <Form
                 onSubmit={this.submit}>
@@ -230,11 +233,13 @@ FormComponent.propTypes = {
   registrationStatus: PropTypes.shape({
     status: PropTypes.bool,
     error: PropTypes.string
-  })
+  }),
+  timeout: PropTypes.bool
 };
 
 FormComponent.defaultProps = {
-  registration: false
+  registration: false,
+  timeout: false
 };
 
 export default withRouter(FormComponent);

--- a/src/containers/auth/LoginContainer.js
+++ b/src/containers/auth/LoginContainer.js
@@ -26,6 +26,7 @@ export class LoginContainer extends Component {
       submit={this.props.login}
       loginStatus={this.props.loginStatus}
       registrationStatus={this.props.registrationStatus}
+      timeout={(this.props.match.path.endsWith("timeout"))}
       />);
   }
 

--- a/src/containers/auth/__tests__/LoginContainer.js
+++ b/src/containers/auth/__tests__/LoginContainer.js
@@ -9,6 +9,9 @@ const Form = Components.Auth.Form;
 const props = {
   login: jest.fn(),
   clear: jest.fn(),
+  match: {
+    path: ""
+  }
 };
 
 const propsWithToken = {

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ ReactDOM.render((
             <Route path="/register" component={Containers.Auth.Register}/>
             <Route path="/forgot" component={Containers.Auth.Forgot}/>
             <Route path="/reset/:id/:token" component={Containers.Auth.Renew}/>
+            <Route path="*" component={IndexRedirect}/>
             <PrivateRoute path="/app" component={App} store={store}/>
           </div>
         </BrowserRouter>

--- a/src/index.js
+++ b/src/index.js
@@ -48,13 +48,13 @@ ReactDOM.render((
       <Provider store={store}>
         <BrowserRouter>
           <div>
-            <Route exact path="/" component={IndexRedirect}/>
+            <Route path="/" component={IndexRedirect} exact/>
             <Route path="/login" component={Containers.Auth.Login} exact/>
+            <Route path="/login/timeout" component={Containers.Auth.Login} exact/>
             <Route path="/login/:prefill" component={Containers.Auth.Login}/>
             <Route path="/register" component={Containers.Auth.Register}/>
             <Route path="/forgot" component={Containers.Auth.Forgot}/>
             <Route path="/reset/:id/:token" component={Containers.Auth.Renew}/>
-            <Route path="*" component={IndexRedirect}/>
             <PrivateRoute path="/app" component={App} store={store}/>
           </div>
         </BrowserRouter>

--- a/src/sagas/aws/accountsSaga.js
+++ b/src/sagas/aws/accountsSaga.js
@@ -8,6 +8,10 @@ export function* getAccountsSaga() {
   try {
     const token = yield getToken();
     const res = yield call(API.AWS.Accounts.getAccounts, token);
+    if (res.success === null) {
+      yield put({type: Constants.LOGOUT_REQUEST});
+      return;
+    }
     if (res.success && res.hasOwnProperty("data"))
       yield put({ type: Constants.AWS_GET_ACCOUNTS_SUCCESS, accounts: res.data });
     else
@@ -21,6 +25,10 @@ export function* getAccountBillsSaga({ accountID }) {
   try {
     const token = yield getToken();
     const res = yield call(API.AWS.Accounts.getAccountBills, accountID, token);
+    if (res.success === null) {
+      yield put({type: Constants.LOGOUT_REQUEST});
+      return;
+    }
     if (res.success && res.hasOwnProperty("data"))
       yield put({ type: Constants.AWS_GET_ACCOUNT_BILLS_SUCCESS, bills: res.data });
     else
@@ -34,6 +42,10 @@ export function* newAccountSaga({ account }) {
   try {
     const token = yield getToken();
     const res = yield call(API.AWS.Accounts.newAccount, account, token);
+    if (res.success === null) {
+      yield put({type: Constants.LOGOUT_REQUEST});
+      return;
+    }
     if (res.success && res.hasOwnProperty("data") && res.data.hasOwnProperty("error"))
       throw Error(res.data.error);
     else if (res.success && res.hasOwnProperty("data"))
@@ -53,6 +65,10 @@ export function* newAccountBillSaga({ accountID, bill }) {
   try {
     const token = yield getToken();
     const res = yield call(API.AWS.Accounts.newAccountBill, accountID, bill, token);
+    if (res.success === null) {
+      yield put({type: Constants.LOGOUT_REQUEST});
+      return;
+    }
     if (res.success && res.hasOwnProperty("data") && res.data.hasOwnProperty("id"))
       yield all([
         put({ type: Constants.AWS_NEW_ACCOUNT_BILL_SUCCESS, bucket: res.data}),
@@ -71,6 +87,10 @@ export function* getAccountBillStatusSaga() {
   try {
     const token = yield getToken();
     const res = yield call(API.AWS.Accounts.getAccountBillsStatus, token);
+    if (res.success === null) {
+      yield put({type: Constants.LOGOUT_REQUEST});
+      return;
+    }
     if (res.success && res.hasOwnProperty("data"))
       yield put({ type: Constants.AWS_GET_ACCOUNT_BILL_STATUS_SUCCESS, values: res.data });
     else
@@ -84,6 +104,10 @@ export function* editAccountSaga({ account }) {
   try {
     const token = yield getToken();
     const res = yield call(API.AWS.Accounts.editAccount, account, token);
+    if (res.success === null) {
+      yield put({type: Constants.LOGOUT_REQUEST});
+      return;
+    }
     if (res.success && res.hasOwnProperty("data"))
       yield all([
         put({ type: Constants.AWS_EDIT_ACCOUNT_SUCCESS }),
@@ -100,6 +124,10 @@ export function* editAccountBillSaga({ accountID, bill }) {
   try {
     const token = yield getToken();
     const res = yield call(API.AWS.Accounts.editAccountBill, accountID, bill, token);
+    if (res.success === null) {
+      yield put({type: Constants.LOGOUT_REQUEST});
+      return;
+    }
     if (res.success && res.hasOwnProperty("data") && res.data.hasOwnProperty("id"))
       yield all([
         put({ type: Constants.AWS_EDIT_ACCOUNT_BILL_SUCCESS }),
@@ -118,6 +146,10 @@ export function* deleteAccountSaga({ accountID }) {
   try {
     const token = yield getToken();
     const res = yield call(API.AWS.Accounts.deleteAccount, accountID, token);
+    if (res.success === null) {
+      yield put({type: Constants.LOGOUT_REQUEST});
+      return;
+    }
     if (res.success && res.hasOwnProperty("data"))
       yield all([
         put({ type: Constants.AWS_DELETE_ACCOUNT_SUCCESS }),
@@ -134,6 +166,10 @@ export function* deleteAccountBillSaga({ accountID, billID }) {
   try {
     const token = yield getToken();
     const res = yield call(API.AWS.Accounts.deleteAccountBill, accountID, billID, token);
+    if (res.success === null) {
+      yield put({type: Constants.LOGOUT_REQUEST});
+      return;
+    }
     if (res.success && res.hasOwnProperty("data"))
       yield all([
         put({ type: Constants.AWS_DELETE_ACCOUNT_BILL_SUCCESS }),
@@ -150,6 +186,10 @@ export function* newExternalSaga() {
   try {
     const token = yield getToken();
     const res = yield call(API.AWS.Accounts.newExternal, token);
+    if (res.success === null) {
+      yield put({type: Constants.LOGOUT_REQUEST});
+      return;
+    }
     if (res.success && res.hasOwnProperty("data") && res.data.hasOwnProperty("external") && res.data.hasOwnProperty("accountId"))
       yield put({ type: Constants.AWS_NEW_EXTERNAL_SUCCESS, external: res.data });
     else

--- a/src/sagas/aws/costsSaga.js
+++ b/src/sagas/aws/costsSaga.js
@@ -18,6 +18,10 @@ export function* getCostsSaga({ id, begin, end, filters, chartType }) {
       res = yield call(API.AWS.Costs.getCostDiff, token, begin, end, filters, accounts);
     else
       res = {success: false};
+    if (res.success === null) {
+      yield put({type: Constants.LOGOUT_REQUEST});
+      return;
+    }
     if (res.success && res.hasOwnProperty("data")) {
       if (res.data.hasOwnProperty("error"))
         throw Error(res.data.error);

--- a/src/sagas/aws/mapSaga.js
+++ b/src/sagas/aws/mapSaga.js
@@ -10,6 +10,10 @@ export function* getMapCostsSaga({ begin, end }) {
     const token = yield getToken();
     const accounts = yield getAWSAccounts();
     const res = yield call(API.AWS.Costs.getCosts, token, begin, end, filters, accounts);
+    if (res.success === null) {
+      yield put({type: Constants.LOGOUT_REQUEST});
+      return;
+    }
     if (res.success && res.hasOwnProperty("data")) {
       if (res.data.hasOwnProperty("error"))
         throw Error(res.data.error);

--- a/src/sagas/aws/reportsSaga.js
+++ b/src/sagas/aws/reportsSaga.js
@@ -9,6 +9,10 @@ export function* getReportsSaga({ accountId }) {
   try {
     const token = yield getToken();
     const res = yield call(API.AWS.Reports.getReports, token, accountId);
+    if (res.success === null) {
+      yield put({type: Constants.LOGOUT_REQUEST});
+      return;
+    }
     if (res.success && res.hasOwnProperty("data") && !res.data.hasOwnProperty("error"))
       yield put({ type: Constants.AWS_GET_REPORTS_SUCCESS, reports: res.data, account: accountId });
     else

--- a/src/sagas/aws/s3Saga.js
+++ b/src/sagas/aws/s3Saga.js
@@ -10,6 +10,10 @@ export function* getS3DataSaga({ begin, end }) {
     const token = yield getToken();
     const accounts = yield getAWSAccounts();
     const res = yield call(API.AWS.S3.getData, token, begin, end, accounts);
+    if (res.success === null) {
+      yield put({type: Constants.LOGOUT_REQUEST});
+      return;
+    }
     if (res.success && res.hasOwnProperty("data") && !res.data.hasOwnProperty("error"))
       yield put({ type: Constants.AWS_GET_S3_DATA_SUCCESS, data: res.data });
     else

--- a/src/sagas/dashboardSaga.js
+++ b/src/sagas/dashboardSaga.js
@@ -22,6 +22,10 @@ export function* getDataSaga({ id, itemType, begin, end, filters }) {
       default:
         res = null;
     }
+    if (res && res.success === null) {
+      yield put({type: Constants.LOGOUT_REQUEST});
+      return;
+    }
     if (res && res.success && res.hasOwnProperty("data")) {
       if (res.data.hasOwnProperty("error"))
         throw Error(res.data.error);

--- a/src/sagas/user/viewersSaga.js
+++ b/src/sagas/user/viewersSaga.js
@@ -7,6 +7,10 @@ export function* getViewersSaga() {
   try {
     const token = yield getToken();
     const res = yield call(API.User.Viewers.list, token);
+    if (res.success === null) {
+      yield put({type: Constants.LOGOUT_REQUEST});
+      return;
+    }
     if (res.success && res.hasOwnProperty('data'))
       yield put({ type: Constants.USER_GET_VIEWERS_SUCCESS, viewers: res.data });
     else
@@ -20,6 +24,10 @@ export function* newViewerSaga({ email }) {
   try {
     const token = yield getToken();
     const res = yield call(API.User.Viewers.create, email, token);
+    if (res.success === null) {
+      yield put({type: Constants.LOGOUT_REQUEST});
+      return;
+    }
     if (res.success && res.hasOwnProperty('data') && res.data.hasOwnProperty('error'))
       throw Error(res.data.error);
     else if (res.success && res.hasOwnProperty('data'))


### PR DESCRIPTION
This PR add support for auto logout when user token expired (API returns 401).

Sagas will now send `LOGOUT_REQUEST` if there is an error with API calls. That constant will trigger the `LogoutSaga` and clear token on LocalStorage & Redux Store.

I also added `store.auth.token` to `AppContainer`, to redirect user if token is no longer available.