### PR TITLE
TRAC-811 Wizard rework. Display minimum policy for TrackIt

### DIFF
--- a/src/actions/aws/accountsActions.js
+++ b/src/actions/aws/accountsActions.js
@@ -14,9 +14,10 @@ export default {
   clearAccountBills: () => ({
     type: Constants.AWS_GET_ACCOUNT_BILLS_CLEAR
   }),
-  newAccount: (account) => ({
+  newAccount: (account, bill) => ({
     type: Constants.AWS_NEW_ACCOUNT,
-    account
+    account,
+    bill
   }),
   clearNewAccount: () => ({
     type: Constants.AWS_NEW_ACCOUNT_CLEAR

--- a/src/components/aws/accounts/WizardComponent.js
+++ b/src/components/aws/accounts/WizardComponent.js
@@ -13,6 +13,7 @@ import Button from 'react-validation/build/button';
 import {CopyToClipboard} from 'react-copy-to-clipboard';
 import Spinner from 'react-spinkit';
 import Misc from '../../misc';
+import BucketForm from './bills/FormComponent';
 import RoleCreation from '../../../assets/wizard-creation.png';
 import RoleARN from '../../../assets/wizard-rolearn.png';
 import Reports_first from '../../../assets/report_step_1.png';
@@ -23,7 +24,7 @@ const Popover = Misc.Popover;
 const Picture = Misc.Picture;
 const Validation = Validations.AWSAccount;
 
-export class StepOne extends Component {
+export class StepRoleCreation extends Component {
 
   submit = (e) => {
     e.preventDefault();
@@ -42,9 +43,7 @@ export class StepOne extends Component {
           <div className="tutorial">
 
             <ol>
-              <li>Go to your <strong>AWS Console</strong></li>
-              <li>In <strong>Services</strong> panel, select <strong>IAM</strong></li>
-              <li>Choose <strong>Role</strong> on the left side menu</li>
+              <li>Go to your <a rel="noopener noreferrer" target="_blank" href="https://console.aws.amazon.com/iam/home#/roles">AWS Console IAM Roles page</a>.</li>
               <li>Click on <strong>Create Role</strong></li>
               <li>
                 <div>
@@ -74,14 +73,17 @@ export class StepOne extends Component {
                 </div>
                 <hr/>
               </li>
-              <li>Select <strong>ReadOnlyAccess</strong> policy</li>
+              <li>Select the policy you created in previous step</li>
               <li>Set a name for this new role and validate</li>
             </ol>
 
           </div>
 
           <div className="form-group clearfix">
-            <button className="btn btn-default col-md-5 btn-left" onClick={this.props.close}>Cancel</button>
+            <div className="btn-group col-md-5" role="group">
+              <div className="btn btn-default btn-left" onClick={this.props.close}>Cancel</div>
+              <div className="btn btn-default btn-left" onClick={this.props.back}>Previous</div>
+            </div>
             <Button className="btn btn-primary col-md-5 btn-right" type="submit">Next</Button>
           </div>
 
@@ -93,16 +95,17 @@ export class StepOne extends Component {
 
 }
 
-StepOne.propTypes = {
+StepRoleCreation.propTypes = {
   external: PropTypes.shape({
     external: PropTypes.string.isRequired,
     accountId: PropTypes.string.isRequired,
   }),
   next: PropTypes.func.isRequired,
+  back: PropTypes.func.isRequired,
   close: PropTypes.func.isRequired
 };
 
-export class StepTwo extends Component {
+export class StepNameARN extends Component {
 
   submit = (e) => {
     e.preventDefault();
@@ -115,11 +118,6 @@ export class StepTwo extends Component {
     this.props.submit(account);
   };
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.account.status && nextProps.account.value && !nextProps.account.hasOwnProperty("error"))
-      nextProps.next();
-  }
-
   render() {
     const error = (this.props.account && this.props.account.status && this.props.account.hasOwnProperty("error")) ? (
       <div className="alert alert-warning" role="alert">{this.props.account.error.message}</div>
@@ -131,7 +129,7 @@ export class StepTwo extends Component {
         <div className="tutorial">
 
           <ol>
-            <li>In <strong>Role</strong> list, select the role you created in previous step</li>
+            <li>In <strong>Roles list</strong> on <a rel="noopener noreferrer" target="_blank" href="https://console.aws.amazon.com/iam/home#/roles">AWS Console IAM Roles page</a>, select the role you created in previous step</li>
             <li>
               <div>
                 Copy the Role ARN in <strong>role summary</strong> to the form below.
@@ -197,7 +195,7 @@ export class StepTwo extends Component {
 
 }
 
-StepTwo.propTypes = {
+StepNameARN.propTypes = {
   external: PropTypes.shape({
     external: PropTypes.string.isRequired,
     accountId: PropTypes.string.isRequired,
@@ -214,30 +212,19 @@ StepTwo.propTypes = {
   submit: PropTypes.func.isRequired,
   next: PropTypes.func.isRequired,
   back: PropTypes.func.isRequired,
-  close: PropTypes.func.isRequired
+  close: PropTypes.func.isRequired,
 };
 
-export class StepThree extends Component {
+export class StepBucket extends Component {
 
   submit = (e) => {
     e.preventDefault();
     const formValues = this.form.getValues();
-    this.props.submit(this.props.account.value.id, formValues);
+    this.props.submit(formValues);
+    this.props.next();
   };
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.bill.status && nextProps.bill.value && !nextProps.bill.hasOwnProperty("error")) {
-        nextProps.close();
-    }
-  }
-
   render() {
-
-    const loading = (this.props.bill && !this.props.bill.status ? (<Spinner className="spinner clearfix" name='circle'/>) : null);
-
-    const error = (this.props.bill && this.props.bill.status && this.props.bill.error ? (
-      <div className="alert alert-warning" role="alert">{this.props.bill.error.message}</div>
-    ) : null);
 
     const tutorial = (
       <div className="tutorial">
@@ -265,11 +252,7 @@ export class StepThree extends Component {
             />
           </li>
           <li>
-            You are almost done !
-            <br/>
             Please fill the name of the bucket you created at <strong>Step 2</strong> in the Form below. <i className="fa fa-arrow-down"/>
-            <br/>
-            <strong>That's it ! </strong><i className="fa fa-smile-o"/>
           </li>
         </ol>
 
@@ -280,7 +263,6 @@ export class StepThree extends Component {
       <div>
 
         {tutorial}
-        {loading || error}
 
         <Form ref={
               /* istanbul ignore next */
@@ -321,18 +303,16 @@ export class StepThree extends Component {
 
               <div className="form-group clearfix">
                 <div className="btn btn-default col-md-5 btn-left" onClick={this.props.close}>Cancel</div>
-                <Button className="btn btn-primary col-md-5 btn-right" type="submit" disabled={!this.props.account}>{!this.props.bill || this.props.bill.status ? "Done" : <Spinner className="spinner" name='circle' color="white"/>}</Button>
+                <Button className="btn btn-primary col-md-5 btn-right" type="submit">Next</Button>
               </div>
-
             </Form>
-
       </div>
     );
   }
 
 }
 
-StepThree.propTypes = {
+StepBucket.propTypes = {
   external: PropTypes.shape({
     external: PropTypes.string.isRequired,
     accountId: PropTypes.string.isRequired,
@@ -354,18 +334,145 @@ StepThree.propTypes = {
   close: PropTypes.func.isRequired
 };
 
+export class StepPolicy extends Component {
+  getPolicy() {
+    const bucketString = this.props.bucketPrefix.length ? `${this.props.bucketName}/${this.props.bucketPrefix}` : this.props.bucketName;
+
+    return(
+      `{
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::${bucketString}/*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetBucketLocation",
+                    "s3:ListBucket"
+                ],
+                "Resource": "arn:aws:s3:::${bucketString}"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "sts:GetCallerIdentity",
+                    "rds:DescribeDBInstances",
+                    "cloudwatch:GetMetricStatistics",
+                    "ec2:DescribeRegions",
+                    "ec2:DescribeInstances"
+                ],
+                "Resource": "*"
+            }
+        ]
+    }`
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        <div className="tutorial">
+          <ol>
+            <li>Go to your <a rel="noopener noreferrer" target="_blank" href="https://console.aws.amazon.com/iam/home#/policies">AWS Console IAM Policies page</a>.</li>
+            <li>Click <strong>Create Policy</strong></li>
+            <li>Select the <strong>JSON</strong> tab</li>
+            <li>
+              Paste the following into the JSON Editor:
+              <CopyToClipboard text={this.getPolicy()}>
+                    <div className="badge">
+                      <i className="fa fa-clipboard" aria-hidden="true"/>
+                    </div>
+              </CopyToClipboard>
+              <pre style={{ height: '180px', marginTop: '10px' }}>
+                {this.getPolicy()}
+              </pre>
+              <div className="alert alert-info">
+                <i className="fa fa-info-circle"></i>
+                &nbsp;
+                With this policy you only gives TrackIt access to the data it needs to be functional. We won't be able to access any of your sensitive data.
+              </div>
+            </li>
+            <li>Click <strong>Review Policy</strong> to submit</li>
+            <li>Give your policy a name and click <strong>Create policy</strong></li>
+          </ol>
+        </div>
+        <div className="form-group clearfix">
+          <div className="btn-group col-md-5" role="group">
+            <div className="btn btn-default btn-left" onClick={this.props.close}>Cancel</div>
+            <div className="btn btn-default btn-left" onClick={this.props.back}>Previous</div>
+          </div>
+          <button className="btn btn-primary col-md-5 btn-right" onClick={this.props.next}>Next</button>
+        </div>
+
+      </div>
+    );
+  }
+}
+
+StepPolicy.propTypes = {
+  bucketName: PropTypes.string.isRequired,
+  bucketPrefix: PropTypes.string.isRequired,
+  next: PropTypes.func.isRequired,
+  back: PropTypes.func.isRequired,
+  close: PropTypes.func.isRequired
+}
+
 class Wizard extends Component {
 
   constructor(props) {
     super(props);
     this.state = {
       open: false,
-      activeStep: 0
+      activeStep: 0,
+      bucket: '',
+      prefix: '',
+      billEditMode: false,
     };
     this.nextStep = this.nextStep.bind(this);
     this.previousStep = this.previousStep.bind(this);
     this.openDialog = this.openDialog.bind(this);
     this.closeDialog = this.closeDialog.bind(this);
+    this.setBucketValues = this.setBucketValues.bind(this);
+    this.submit = this.submit.bind(this);
+    this.submitBucket = this.submitBucket.bind(this);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // Everything went well
+    if (
+      (nextProps.account.status && nextProps.account.value && !nextProps.account.hasOwnProperty("error"))
+      && (nextProps.bill.status && nextProps.bill.value && !nextProps.bill.hasOwnProperty("error"))
+    ) {
+      this.closeDialog();
+    }
+    // Account was created successfully but not bill
+    else if (
+      (nextProps.account.status && nextProps.account.value && !nextProps.account.hasOwnProperty("error"))
+      && (nextProps.bill.status && nextProps.bill.hasOwnProperty("error"))
+    ) {
+      this.setState({ billEditMode : true });
+    }
+
+  }
+
+  setBucketValues(values) {
+    const { bucket, prefix } = values;
+    this.setState({ bucket, prefix });
+  }
+
+  submit(account) {
+    const bucket = {
+      bucket: this.state.bucket,
+      prefix: this.state.prefix,
+    }
+    this.props.submitAccount(account, bucket);
+  }
+
+  submitBucket(bucket) {
+    this.props.submitBucket(this.props.account.value.id, bucket);
   }
 
   nextStep = () => {
@@ -388,7 +495,7 @@ class Wizard extends Component {
   closeDialog = (e=null) => {
     if (e)
       e.preventDefault();
-    this.setState({open: false, activeStep: 0});
+    this.setState({open: false, activeStep: 0, bucket: '', prefix: '', billEditMode: false });
     this.props.clearAccount();
     this.props.clearBucket();
   };
@@ -397,19 +504,67 @@ class Wizard extends Component {
 
     let steps = [
       {
+        title: "Create a billing bucket",
+        label: "Billing bucket",
+        component: <StepBucket account={this.props.account} bill={this.props.bill} next={this.nextStep} submit={this.setBucketValues} close={this.closeDialog}/>
+      },
+      {
+        title: "Create a policy",
+        label: "Policy creation",
+        component: <StepPolicy bucketName={this.state.bucket} bucketPrefix={this.state.prefix} next={this.nextStep} back={this.previousStep} close={this.closeDialog}/>
+      },
+      {
         title: "Create a role",
         label: "Role creation",
-        component: <StepOne external={this.props.external} next={this.nextStep} close={this.closeDialog}/>
-      },{
+        component: <StepRoleCreation external={this.props.external} next={this.nextStep} back={this.previousStep} close={this.closeDialog}/>
+      },
+      {
         title: "Add your role",
-        label: "Name",
-        component: <StepTwo external={this.props.external} account={this.props.account} submit={this.props.submitAccount} next={this.nextStep} back={this.previousStep} close={this.closeDialog}/>
-      },{
-        title: "Add a bill repository",
-        label: "Bill repository",
-        component: <StepThree account={this.props.account} bill={this.props.bill} submit={this.props.submitBucket} close={this.closeDialog}/>
-      }
+        label: "Role ARN & Name",
+        component: <StepNameARN external={this.props.external} account={this.props.account} submit={this.submit} next={this.nextStep} back={this.previousStep} close={this.closeDialog}/>
+      },
     ];
+
+    const stepper = (
+      <div>
+        <div>
+          {steps[this.state.activeStep].component}
+        </div>
+
+        <Stepper nonLinear activeStep={this.state.activeStep} className="account-wizard-stepper">
+          {steps.map((step, index) => (
+              <Step key={index}>
+                <StepButton
+                  className={"account-wizard-stepper-item " + (this.state.activeStep > index ? "completed" : (this.state.activeStep === index ? "current" : "")) }
+                  completed={this.state.activeStep > index}
+                >
+                  {step.label}
+                </StepButton>
+              </Step>
+            ))}
+        </Stepper>
+      </div>
+    );
+
+    let billEditMode;
+    if (this.props.account && this.props.account.value && this.props.account.value.id) {
+      billEditMode = (
+        <div>
+          <div className="alert alert-warning">
+            Your account was created successfully but we could not access the billing bucket you specified.
+            Please click on the <strong>Add a bill location</strong> button below and try to set it up again. Thank you !
+          </div>
+          <BucketForm
+            account={this.props.account.value && this.props.account.value.id}
+            submit={this.submitBucket}
+            status={this.props.bill}
+            clear={this.props.clearBucket}
+          />
+          <hr />
+          <button className="btn btn-default" onClick={this.closeDialog}>Close</button>
+        </div>
+      );  
+    }
 
     return(
       <div className="account-wizard">
@@ -421,24 +576,7 @@ class Wizard extends Component {
           <DialogTitle disableTypography><h1>Add an AWS account : {steps[this.state.activeStep].title}</h1></DialogTitle>
 
           <DialogContent>
-
-            <div>
-              {steps[this.state.activeStep].component}
-            </div>
-
-            <Stepper nonLinear activeStep={this.state.activeStep} className="account-wizard-stepper">
-              {steps.map((step, index) => (
-                  <Step key={index}>
-                    <StepButton
-                      className={"account-wizard-stepper-item " + (this.state.activeStep > index ? "completed" : (this.state.activeStep === index ? "current" : "")) }
-                      completed={this.state.activeStep > index}
-                    >
-                      {step.label}
-                    </StepButton>
-                  </Step>
-                ))}
-            </Stepper>
-
+            {this.state.billEditMode ? billEditMode : stepper}
           </DialogContent>
 
         </Dialog>
@@ -468,8 +606,8 @@ Wizard.propTypes = {
     error: PropTypes.instanceOf(Error)
   }),
   submitAccount: PropTypes.func.isRequired,
-  clearAccount: PropTypes.func.isRequired,
   submitBucket: PropTypes.func.isRequired,
+  clearAccount: PropTypes.func.isRequired,
   clearBucket: PropTypes.func.isRequired,
 };
 

--- a/src/components/aws/accounts/__tests__/WizardComponent.js
+++ b/src/components/aws/accounts/__tests__/WizardComponent.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import WizardComponent, {
-  StepOne,
-  StepTwo,
+  StepRoleCreation,
+  StepNameARN,
   StepThree
 } from '../WizardComponent';
 import Dialog from '@material-ui/core/Dialog';
@@ -124,16 +124,16 @@ describe('<WizardComponent />', () => {
     expect(children.length).toBe(1);
   });
 
-  it('renders three <Step /> components', () => {
+  it('renders four <Step /> components', () => {
     const wrapper = shallow(<WizardComponent {...props}/>);
     const children = wrapper.find(Step);
-    expect(children.length).toBe(3);
+    expect(children.length).toBe(4);
   });
 
-  it('renders three <StepButton /> components', () => {
+  it('renders four <StepButton /> components', () => {
     const wrapper = shallow(<WizardComponent {...props}/>);
     const children = wrapper.find(StepButton);
-    expect(children.length).toBe(3);
+    expect(children.length).toBe(4);
   });
 
   it('can go to next and previous step', () => {
@@ -147,7 +147,7 @@ describe('<WizardComponent />', () => {
 
 });
 
-describe('<StepOne />', () => {
+describe('<StepRoleCreation />', () => {
 
   const props = {
     external,
@@ -159,45 +159,38 @@ describe('<StepOne />', () => {
     jest.resetAllMocks();
   });
 
-  it('renders a <StepOne /> component', () => {
-    const wrapper = shallow(<StepOne {...props}/>);
+  it('renders a <StepRoleCreation /> component', () => {
+    const wrapper = shallow(<StepRoleCreation {...props}/>);
     expect(wrapper.length).toBe(1);
   });
 
   it('renders a <div /> component for tutorial', () => {
-    const wrapper = shallow(<StepOne {...props}/>);
+    const wrapper = shallow(<StepRoleCreation {...props}/>);
     const children = wrapper.find("div.tutorial");
     expect(children.length).toBe(1);
   });
 
   it('renders a <Picture /> component in <div /> tutorial', () => {
-    const wrapper = shallow(<StepOne {...props}/>);
+    const wrapper = shallow(<StepRoleCreation {...props}/>);
     const picture = wrapper.find(Picture);
     expect(picture.length).toBe(1);
   });
 
   it('renders a <Form /> component', () => {
-    const wrapper = shallow(<StepOne {...props}/>);
+    const wrapper = shallow(<StepRoleCreation {...props}/>);
     const form = wrapper.find(Form);
     expect(form.length).toBe(1);
   });
 
   it('renders 1 <Button /> component in <Form />', () => {
-    const wrapper = shallow(<StepOne {...props}/>);
+    const wrapper = shallow(<StepRoleCreation {...props}/>);
     const form = wrapper.find(Form);
     const button = form.find(Button);
     expect(button.length).toBe(1);
   });
 
-  it('renders 1 <button /> component in <Form />', () => {
-    const wrapper = shallow(<StepOne {...props}/>);
-    const form = wrapper.find(Form);
-    const button = form.find("button");
-    expect(button.length).toBe(1);
-  });
-
   it('can submit', () => {
-    const wrapper = shallow(<StepOne {...props}/>);
+    const wrapper = shallow(<StepRoleCreation {...props}/>);
     expect(props.next).not.toHaveBeenCalled();
     wrapper.instance().submit({ preventDefault() {} });
     expect(props.next).toHaveBeenCalled();
@@ -205,7 +198,7 @@ describe('<StepOne />', () => {
 
 });
 
-describe('<StepTwo />', () => {
+describe('<StepNameARN />', () => {
 
   const props = {
     account: accountEmpty,
@@ -235,67 +228,67 @@ describe('<StepTwo />', () => {
     jest.resetAllMocks();
   });
 
-  it('renders a <StepTwo /> component', () => {
-    const wrapper = shallow(<StepTwo {...props}/>);
+  it('renders a <StepNameARN /> component', () => {
+    const wrapper = shallow(<StepNameARN {...props}/>);
     expect(wrapper.length).toBe(1);
   });
 
   it('renders a <div /> component for tutorial', () => {
-    const wrapper = shallow(<StepTwo {...props}/>);
+    const wrapper = shallow(<StepNameARN {...props}/>);
     const children = wrapper.find("div.tutorial");
     expect(children.length).toBe(1);
   });
 
   it('renders a <Picture /> component in <div /> tutorial', () => {
-    const wrapper = shallow(<StepTwo {...props}/>);
+    const wrapper = shallow(<StepNameARN {...props}/>);
     const picture = wrapper.find(Picture);
     expect(picture.length).toBe(1);
   });
 
   it('renders a <Form /> component', () => {
-    const wrapper = shallow(<StepTwo {...props}/>);
+    const wrapper = shallow(<StepNameARN {...props}/>);
     const form = wrapper.find(Form);
     expect(form.length).toBe(1);
   });
 
   it('renders 2 <Input /> components in <Form />', () => {
-    const wrapper = shallow(<StepTwo {...props}/>);
+    const wrapper = shallow(<StepNameARN {...props}/>);
     const form = wrapper.find(Form);
     const inputs = form.find(Input);
     expect(inputs.length).toBe(2);
   });
 
   it('renders 1 <Button /> component in <Form />', () => {
-    const wrapper = shallow(<StepTwo {...props}/>);
+    const wrapper = shallow(<StepNameARN {...props}/>);
     const form = wrapper.find(Form);
     const button = form.find(Button);
     expect(button.length).toBe(1);
   });
 
   it('renders 2 <button /> components in <Form />', () => {
-    const wrapper = shallow(<StepTwo {...props}/>);
+    const wrapper = shallow(<StepNameARN {...props}/>);
     const form = wrapper.find(Form);
     const button = form.find("div.btn");
     expect(button.length).toBe(2);
   });
 
   it('renders a <Spinner /> component if waiting for response', () => {
-    let wrapper = shallow(<StepTwo {...props}/>);
+    let wrapper = shallow(<StepNameARN {...props}/>);
     let spinner = wrapper.find(Spinner);
     expect(spinner.length).toBe(0);
-    wrapper = shallow(<StepTwo {...propsWaiting}/>);
+    wrapper = shallow(<StepNameARN {...propsWaiting}/>);
     spinner = wrapper.find(Spinner);
     expect(spinner.length).toBe(1);
   });
 
   it('renders an alert if there is an error', () => {
-    const wrapper = shallow(<StepTwo {...propsError}/>);
+    const wrapper = shallow(<StepNameARN {...propsError}/>);
     const error = wrapper.find("div.alert");
     expect(error.length).toBe(1);
   });
 
   it('can submit', () => {
-    const wrapper = shallow(<StepTwo {...props}/>);
+    const wrapper = shallow(<StepNameARN {...props}/>);
     const instance = wrapper.instance();
     instance.form = {
       getValues: () => ({
@@ -306,137 +299,6 @@ describe('<StepTwo />', () => {
     expect(props.submit).not.toHaveBeenCalled();
     wrapper.instance().submit({ preventDefault() {} });
     expect(props.submit).toHaveBeenCalled();
-  });
-
-  it('can go to next page when data is available', () => {
-    const wrapper = shallow(<StepTwo {...props}/>);
-    expect(props.next).not.toHaveBeenCalled();
-    wrapper.instance().componentWillReceiveProps(propsWaiting);
-    expect(props.next).not.toHaveBeenCalled();
-    wrapper.instance().componentWillReceiveProps(propsDone);
-    expect(props.next).toHaveBeenCalled();
-  });
-
-});
-
-describe('<StepThree />', () => {
-
-  const props = {
-    account,
-    external,
-    submit: jest.fn(),
-    close: jest.fn()
-  };
-
-  const propsWithoutBill = {
-    ...props,
-    bill: null
-  };
-
-  const propsWithoutAccount = {
-    ...props,
-    account: null,
-    bill
-  };
-
-  const propsWaiting = {
-    ...props,
-    bill: billWaiting
-  };
-
-  const propsDone = {
-    ...props,
-    bill
-  };
-
-  const propsError = {
-    ...props,
-    bill: billError
-  };
-
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
-
-  it('renders a <StepThree /> component', () => {
-    const wrapper = shallow(<StepThree {...propsWithoutAccount}/>);
-    expect(wrapper.length).toBe(1);
-  });
-
-  it('renders a <div /> component for tutorial', () => {
-    const wrapper = shallow(<StepThree {...propsWithoutAccount}/>);
-    const children = wrapper.find("div.tutorial");
-    expect(children.length).toBe(1);
-  });
-
-  it('renders a <Form /> component', () => {
-    const wrapper = shallow(<StepThree {...propsWithoutAccount}/>);
-    const form = wrapper.find(Form);
-    expect(form.length).toBe(1);
-  });
-
-  it('renders 2 <Input /> component in <Form />', () => {
-    const wrapper = shallow(<StepThree {...propsWithoutAccount}/>);
-    const form = wrapper.find(Form);
-    const inputs = form.find(Input);
-    expect(inputs.length).toBe(2);
-  });
-
-  it('renders 1 <Button /> component in <Form />', () => {
-    let wrapper = shallow(<StepThree {...propsWithoutAccount}/>);
-    let form = wrapper.find(Form);
-    let button = form.find(Button);
-    expect(button.length).toBe(1);
-    expect(button.prop("disabled")).toBe(true);
-    wrapper = shallow(<StepThree {...propsWaiting}/>);
-    form = wrapper.find(Form);
-    button = form.find(Button);
-    expect(button.length).toBe(1);
-    expect(button.prop("disabled")).toBe(false);
-  });
-
-  it('renders 1 <button /> component in <Form />', () => {
-    const wrapper = shallow(<StepThree {...propsWithoutAccount}/>);
-    const form = wrapper.find(Form);
-    const button = form.find("div.btn");
-    expect(button.length).toBe(1);
-  });
-
-  it('renders a <Spinner /> component if waiting for response', () => {
-    let wrapper = shallow(<StepThree {...propsWithoutAccount}/>);
-    let spinner = wrapper.find(Spinner);
-    expect(spinner.length).toBe(0);
-    wrapper = shallow(<StepThree {...propsWaiting}/>);
-    spinner = wrapper.find(Spinner);
-    expect(spinner.length).toBe(2);
-  });
-
-  it('renders an alert if there is an error', () => {
-    const wrapper = shallow(<StepThree {...propsError}/>);
-    const error = wrapper.find("div.alert");
-    expect(error.length).toBe(1);
-  });
-
-  it('can submit', () => {
-    const wrapper = shallow(<StepThree {...propsWithoutBill}/>);
-    const instance = wrapper.instance();
-    instance.form = {
-      getValues: () => ({
-        bucket: "s3://account/path/to/bills"
-      })
-    };
-    expect(props.submit).not.toHaveBeenCalled();
-    wrapper.instance().submit({ preventDefault() {} });
-    expect(props.submit).toHaveBeenCalled();
-  });
-
-  it('can go to next page when data is available', () => {
-    const wrapper = shallow(<StepThree {...propsWithoutBill}/>);
-    expect(props.close).not.toHaveBeenCalled();
-    wrapper.instance().componentWillReceiveProps(propsWaiting);
-    expect(props.close).not.toHaveBeenCalled();
-    wrapper.instance().componentWillReceiveProps(propsDone);
-    expect(props.close).toHaveBeenCalled();
   });
 
 });

--- a/src/components/aws/accounts/bills/FormComponent.js
+++ b/src/components/aws/accounts/bills/FormComponent.js
@@ -112,7 +112,9 @@ class FormComponent extends Component {
       <div>
 
         <button className="btn btn-default" onClick={this.openDialog}>
-          {this.props.bill !== undefined ? "Edit" : "Add"}
+          {this.props.bill !== undefined ? <i className="fa fa-edit"/> : <i className="fa fa-plus"/>}
+          &nbsp;
+          {this.props.bill !== undefined ? "Edit" : "Add a bill location"}
         </button>
 
         <Dialog open={this.state.open} fullWidth>

--- a/src/components/aws/accounts/bills/ListComponent.js
+++ b/src/components/aws/accounts/bills/ListComponent.js
@@ -68,6 +68,7 @@ export class Item extends Component {
               submit={this.editBill}
               status={this.props.editionStatus}
               clear={this.props.clearEdition}
+              bills={this.props.bills}
             />
           </div>
           &nbsp;
@@ -146,6 +147,7 @@ export class ListComponent extends Component {
       submit={this.newBill}
       status={this.props.billCreation}
       clear={this.props.clearNewBill}
+      bills={this.props.bills}
     />);
 
     return (

--- a/src/components/aws/accounts/bills/__tests__/FormComponent.js
+++ b/src/components/aws/accounts/bills/__tests__/FormComponent.js
@@ -72,6 +72,7 @@ describe('<FormComponent />', () => {
     instance.form = form;
     expect(props.submit).not.toHaveBeenCalled();
     wrapper.instance().submit({ preventDefault(){} });
+    wrapper.instance().submit({ preventDefault(){} });
     expect(props.submit).toHaveBeenCalled();
   });
 

--- a/src/containers/setup/aws/AccountsContainer.js
+++ b/src/containers/setup/aws/AccountsContainer.js
@@ -178,8 +178,8 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(Actions.AWS.Accounts.getAccounts())
   },
   accountActions: {
-    new: (account) => {
-      dispatch(Actions.AWS.Accounts.newAccount(account))
+    new: (account, bill) => {
+      dispatch(Actions.AWS.Accounts.newAccount(account, bill))
     },
     clearNew: () => {
       dispatch(Actions.AWS.Accounts.clearNewAccount());

--- a/src/sagas/aws/__tests__/accountsSaga.js
+++ b/src/sagas/aws/__tests__/accountsSaga.js
@@ -78,14 +78,15 @@ describe("Accounts Saga", () => {
 
   describe("New Account", () => {
 
-    const account = {roleArn: "roleArn"};
+    const account = {roleArn: "roleArn", id: 42};
+    const bill = { bucket: "test", prefix: ""};
     const validResponse = { success: true, data: account };
     const invalidResponse = { success: true, account };
     const noResponse = { success: false };
 
     it("handles saga with valid data", () => {
 
-      let saga = newAccountSaga({account});
+      let saga = newAccountSaga({account, bill});
 
       expect(saga.next().value)
         .toEqual(getToken());
@@ -97,7 +98,8 @@ describe("Accounts Saga", () => {
         .toEqual(all([
           put({ type: Constants.AWS_NEW_ACCOUNT_SUCCESS, account }),
           put({ type: Constants.AWS_NEW_EXTERNAL }),
-          put({ type: Constants.AWS_GET_ACCOUNTS })
+          put({ type: Constants.AWS_GET_ACCOUNTS }),
+          put({ type : Constants.AWS_NEW_ACCOUNT_BILL, accountID: 42, bill})
         ]));
 
       expect(saga.next().done).toBe(true);
@@ -416,7 +418,8 @@ describe("Account Bills Saga", () => {
       expect(saga.next(validResponse).value)
         .toEqual(all([
           put({ type: Constants.AWS_NEW_ACCOUNT_BILL_SUCCESS, bucket: bill }),
-          put({ type: Constants.AWS_GET_ACCOUNT_BILLS, accountID })
+          put({ type: Constants.AWS_GET_ACCOUNT_BILLS, accountID }),
+          put({ type: Constants.AWS_GET_ACCOUNTS }),
         ]));
 
       expect(saga.next().done).toBe(true);
@@ -579,7 +582,8 @@ describe("Account Bills Saga", () => {
       expect(saga.next(validResponse).value)
         .toEqual(all([
           put({ type: Constants.AWS_DELETE_ACCOUNT_BILL_SUCCESS }),
-          put({ type: Constants.AWS_GET_ACCOUNT_BILLS, accountID })
+          put({ type: Constants.AWS_GET_ACCOUNT_BILLS, accountID }),
+          put({ type: Constants.AWS_GET_ACCOUNTS }),
         ]));
 
       expect(saga.next().done).toBe(true);

--- a/src/sagas/aws/accountsSaga.js
+++ b/src/sagas/aws/accountsSaga.js
@@ -38,7 +38,7 @@ export function* getAccountBillsSaga({ accountID }) {
   }
 }
 
-export function* newAccountSaga({ account }) {
+export function* newAccountSaga({ account, bill }) {
   try {
     const token = yield getToken();
     const res = yield call(API.AWS.Accounts.newAccount, account, token);
@@ -48,12 +48,14 @@ export function* newAccountSaga({ account }) {
     }
     if (res.success && res.hasOwnProperty("data") && res.data.hasOwnProperty("error"))
       throw Error(res.data.error);
-    else if (res.success && res.hasOwnProperty("data"))
+    else if (res.success && res.hasOwnProperty("data")) {
       yield all([
         put({ type: Constants.AWS_NEW_ACCOUNT_SUCCESS, account: res.data }),
         put({ type: Constants.AWS_NEW_EXTERNAL }),
-        put({ type: Constants.AWS_GET_ACCOUNTS })
+        put({ type: Constants.AWS_GET_ACCOUNTS }),
+        put({ type : Constants.AWS_NEW_ACCOUNT_BILL, accountID: res.data.id, bill})
       ]);
+    }
     else
       throw Error("Error with request");
   } catch (error) {
@@ -72,7 +74,8 @@ export function* newAccountBillSaga({ accountID, bill }) {
     if (res.success && res.hasOwnProperty("data") && res.data.hasOwnProperty("id"))
       yield all([
         put({ type: Constants.AWS_NEW_ACCOUNT_BILL_SUCCESS, bucket: res.data}),
-        put({ type: Constants.AWS_GET_ACCOUNT_BILLS, accountID })
+        put({ type: Constants.AWS_GET_ACCOUNT_BILLS, accountID }),
+        put({ type: Constants.AWS_GET_ACCOUNTS }),
       ]);
     else if (res.success && res.hasOwnProperty("data") && res.data.hasOwnProperty("error"))
       throw Error(res.data.error);
@@ -173,7 +176,8 @@ export function* deleteAccountBillSaga({ accountID, billID }) {
     if (res.success && res.hasOwnProperty("data"))
       yield all([
         put({ type: Constants.AWS_DELETE_ACCOUNT_BILL_SUCCESS }),
-        put({ type: Constants.AWS_GET_ACCOUNT_BILLS, accountID })
+        put({ type: Constants.AWS_GET_ACCOUNT_BILLS, accountID }),
+        put({ type: Constants.AWS_GET_ACCOUNTS }),
       ]);
     else
       throw Error("Error with request");

--- a/src/styles/Wizard.css
+++ b/src/styles/Wizard.css
@@ -4,7 +4,7 @@
 }
 
 .account-wizard-stepper .account-wizard-stepper-item svg text {
-	font-size: 0.8em;
+	font-size: 0.5em;
 }
 
 .account-wizard-stepper .account-wizard-stepper-item p {


### PR DESCRIPTION
This reworks the Add account wizard.

We now ask for the user to create the billing bucket first, then generate a minimum policy for trackit to work using this bucket and then ask for the Role creation.

Here are screenshots of all Wizard steps : 

![bucket](https://user-images.githubusercontent.com/3480526/44540923-af741f00-a708-11e8-91ca-f0d2687a0c43.png)

![policy](https://user-images.githubusercontent.com/3480526/44540929-b26f0f80-a708-11e8-9323-0a59c458275f.png)

![role1](https://user-images.githubusercontent.com/3480526/44540932-b4d16980-a708-11e8-91f5-a21395f84f71.png)

![role2](https://user-images.githubusercontent.com/3480526/44540936-b733c380-a708-11e8-80c3-5e8e3e30a88e.png)

I adapted the existing tests for the Wizard but had to remove the all StepThree part since it wasn't matching the new workflow. This dropped our coverage on the Wizard component to 68% I'll fix that later.

Since we are creating the account first and then trying to add a bucket to it the user might get an error if the bucket info is wrong. This would display a specific screen inviting the user to try again : 

![bucket_error](https://user-images.githubusercontent.com/3480526/44541012-01b54000-a709-11e8-8d01-b746dea8b856.png)
