### PR TITLE
Add multi-accounts support for Resources List

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -103,6 +103,10 @@ export class App extends Component {
               component={hasAccounts ? Containers.AWS.Resources : redirectToSetup}
             />
             <Route
+              path={this.props.match.url + '/resources'}
+              component={hasAccounts ? Containers.AWS.Resources : redirectToSetup}
+            />
+            <Route
               path={this.props.match.url + "/setup/:hasAccounts*"}
               component={this.props.token ? Containers.Setup.Main : redirectToLogin}
             />

--- a/src/App.js
+++ b/src/App.js
@@ -103,10 +103,6 @@ export class App extends Component {
               component={hasAccounts ? Containers.AWS.Resources : redirectToSetup}
             />
             <Route
-              path={this.props.match.url + '/resources'}
-              component={hasAccounts ? Containers.AWS.Resources : redirectToSetup}
-            />
-            <Route
               path={this.props.match.url + "/setup/:hasAccounts*"}
               component={this.props.token ? Containers.Setup.Main : redirectToLogin}
             />

--- a/src/actions/aws/resourcesActions.js
+++ b/src/actions/aws/resourcesActions.js
@@ -1,19 +1,9 @@
 import Constants from '../../constants';
 
 export default {
-	selectAccount: (accountId) => ({
-		type: Constants.AWS_RESOURCES_ACCOUNT_SELECTION,
-		accountId
-	}),
 	get: {
-		EC2: (accountId) => ({
-      type: Constants.AWS_RESOURCES_GET_EC2,
-      accountId
-    }),
-    RDS: (accountId) => ({
-      type: Constants.AWS_RESOURCES_GET_RDS,
-      accountId
-    })
+		EC2: () => ({type: Constants.AWS_RESOURCES_GET_EC2}),
+    RDS: () => ({type: Constants.AWS_RESOURCES_GET_RDS})
 	},
 	clear: {
 		EC2: () => ({type: Constants.AWS_RESOURCES_GET_EC2_CLEAR}),

--- a/src/api/aws/resources.js
+++ b/src/api/aws/resources.js
@@ -1,11 +1,15 @@
 import { call } from "../misc";
 
-export const getEC2 = (token, accountId) => {
-  let route = `/ec2?account=${accountId}`;
+export const getEC2 = (token, accounts=undefined) => {
+  let route = `/ec2`;
+  if (accounts && accounts.length)
+    route += `?accounts=${accounts.join(',')}`;
   return call(route, 'GET', null, token);
 };
 
-export const getRDS = (token, accountId) => {
-  let route = `/rds?account=${accountId}`;
+export const getRDS = (token, accounts=undefined) => {
+  let route = `/rds`;
+  if (accounts && accounts.length)
+    route += `?accounts=${accounts.join(',')}`;
   return call(route, 'GET', null, token);
 };

--- a/src/components/aws/resources/DatabasesComponent.js
+++ b/src/components/aws/resources/DatabasesComponent.js
@@ -162,12 +162,20 @@ export class DatabasesComponent extends Component {
 DatabasesComponent.propTypes = {
   accounts: PropTypes.arrayOf(PropTypes.object),
   data: PropTypes.shape({
-    dbInstanceIdentifier: PropTypes.string.isRequired,
-    dbInstanceClass: PropTypes.string.isRequired,
-    availabilityZone: PropTypes.string.isRequired,
-    engine: PropTypes.string.isRequired,
-    multiAZ: PropTypes.string.isRequired,
-    allocatedStorage: PropTypes.number.isRequired
+    status: PropTypes.bool.isRequired,
+    error: PropTypes.instanceOf(Error),
+    value: PropTypes.arrayOf(PropTypes.shape({
+      account: PropTypes.string.isRequired,
+      reportDate: PropTypes.string.isRequired,
+      instances: PropTypes.arrayOf(PropTypes.shape({
+        dbInstanceIdentifier: PropTypes.string.isRequired,
+        dbInstanceClass: PropTypes.string.isRequired,
+        availabilityZone: PropTypes.string.isRequired,
+        engine: PropTypes.string.isRequired,
+        multiAZ: PropTypes.bool.isRequired,
+        allocatedStorage: PropTypes.number.isRequired
+      }))
+    }))
   }),
   getData: PropTypes.func.isRequired,
   clear: PropTypes.func.isRequired,

--- a/src/components/aws/resources/DatabasesComponent.js
+++ b/src/components/aws/resources/DatabasesComponent.js
@@ -13,15 +13,12 @@ const Tooltip = Misc.Popover;
 export class DatabasesComponent extends Component {
 
   componentWillMount() {
-    if (this.props.account)
-      this.props.getData(this.props.account);
+    this.props.getData();
   }
 
   componentWillReceiveProps(nextProps) {
-    if (!nextProps.account)
-      nextProps.clear();
-    else if (nextProps.account !== this.props.account)
-      nextProps.getData(nextProps.account);
+    if (nextProps.accounts !== this.props.accounts)
+      nextProps.getData();
   }
 
   render() {
@@ -31,8 +28,11 @@ export class DatabasesComponent extends Component {
     let reportDate = null;
     let instances = [];
     if (this.props.data.status && this.props.data.hasOwnProperty("value") && this.props.data.value) {
-      reportDate = (<Tooltip info tooltip={"Report created " + Moment(this.props.data.value.reportDate).fromNow()}/>);
-      instances = this.props.data.value.instances;
+      const reportsDates = this.props.data.value.map((account) => (Moment(account.reportDate)));
+      const oldestReport = Moment.min(reportsDates);
+      const newestReport = Moment.max(reportsDates);
+      reportDate = (<Tooltip info tooltip={"Reports created between " + oldestReport.format("ddd d MMM HH:mm") + " and " + newestReport.format("ddd d MMM HH:mm")}/>);
+      instances = this.props.data.value.map((account) => (account.instances)).flat();
     }
 
     const availabilityZones = [];
@@ -160,7 +160,7 @@ export class DatabasesComponent extends Component {
 }
 
 DatabasesComponent.propTypes = {
-  account: PropTypes.string,
+  accounts: PropTypes.arrayOf(PropTypes.object),
   data: PropTypes.shape({
     dbInstanceIdentifier: PropTypes.string.isRequired,
     dbInstanceClass: PropTypes.string.isRequired,
@@ -175,7 +175,7 @@ DatabasesComponent.propTypes = {
 
 /* istanbul ignore next */
 const mapStateToProps = ({aws}) => ({
-  account: aws.resources.account,
+  accounts: aws.accounts.selection,
   data: aws.resources.RDS
 });
 

--- a/src/components/aws/resources/DatabasesComponent.js
+++ b/src/components/aws/resources/DatabasesComponent.js
@@ -32,7 +32,7 @@ export class DatabasesComponent extends Component {
       const oldestReport = Moment.min(reportsDates);
       const newestReport = Moment.max(reportsDates);
       reportDate = (<Tooltip info tooltip={"Reports created between " + oldestReport.format("ddd d MMM HH:mm") + " and " + newestReport.format("ddd d MMM HH:mm")}/>);
-      instances = this.props.data.value.map((account) => (account.instances)).flat();
+      instances = [].concat.apply([], this.props.data.value.map((account) => (account.instances)));
     }
 
     const availabilityZones = [];

--- a/src/components/aws/resources/VMsComponent.js
+++ b/src/components/aws/resources/VMsComponent.js
@@ -95,7 +95,7 @@ export class VMsComponent extends Component {
       const oldestReport = Moment.min(reportsDates);
       const newestReport = Moment.max(reportsDates);
       reportDate = (<Tooltip info tooltip={"Reports created between " + oldestReport.format("ddd d MMM HH:mm") + " and " + newestReport.format("ddd d MMM HH:mm")}/>);
-      instances = this.props.data.value.map((account) => (account.instances)).flat();
+      instances = [].concat.apply([], this.props.data.value.map((account) => (account.instances)));
     }
 
     const regions = [];

--- a/src/components/aws/resources/VMsComponent.js
+++ b/src/components/aws/resources/VMsComponent.js
@@ -345,7 +345,7 @@ VMsComponent.propTypes = {
   data: PropTypes.shape({
     status: PropTypes.bool.isRequired,
     error: PropTypes.instanceOf(Error),
-    value: PropTypes.shape({
+    value: PropTypes.arrayOf(PropTypes.shape({
       account: PropTypes.string.isRequired,
       reportDate: PropTypes.string.isRequired,
       instances: PropTypes.arrayOf(
@@ -364,7 +364,7 @@ VMsComponent.propTypes = {
           tags: PropTypes.object.isRequired
         })
       )
-    })
+    }))
   }),
   getData: PropTypes.func.isRequired,
   clear: PropTypes.func.isRequired,

--- a/src/components/aws/resources/__tests__/DatabasesComponent.js
+++ b/src/components/aws/resources/__tests__/DatabasesComponent.js
@@ -10,28 +10,29 @@ const Tooltip = Misc.Popover;
 
 const props = {
   getData: jest.fn(),
-  clear: jest.fn(),
-  account: '420'
+  clear: jest.fn()
 };
 
 const propsWithData = {
   ...props,
   data: {
     status: true,
-    value: {
-      account: '420',
-      reportDate: Moment().toISOString(),
-      instances: [
-        {
-          dbInstanceIdentifier: 'name',
-          dbInstanceClass: 'type',
-          availabilityZone: 'us-west-1',
-          engine: 'engine',
-          multiAZ: 'yes',
-          allocatedStorage: 42
-        }
-      ]
-    }
+    value: [
+      {
+        account: '420',
+        reportDate: Moment().toISOString(),
+        instances: [
+          {
+            dbInstanceIdentifier: 'name',
+            dbInstanceClass: 'type',
+            availabilityZone: 'us-west-1',
+            engine: 'engine',
+            multiAZ: 'yes',
+            allocatedStorage: 42
+          }
+        ]
+      }
+    ]
   }
 };
 

--- a/src/components/aws/resources/__tests__/VMsComponent.js
+++ b/src/components/aws/resources/__tests__/VMsComponent.js
@@ -10,40 +10,41 @@ const Tooltip = Misc.Popover;
 
 const props = {
   getData: jest.fn(),
-  clear: jest.fn(),
-  account: '420'
+  clear: jest.fn()
 };
 
 const propsWithData = {
   ...props,
   data: {
     status: true,
-    value: {
-      account: '420',
-      reportDate: Moment().toISOString(),
-      instances: [
-        {
-          id: '42',
-          state: 'running',
-          region: 'us-west-1',
-          cpuAverage: 42,
-          cpuPeak: 42,
-          ioRead: {
-            internal: 42
-          },
-          ioWrite: {
-            internal: 42
-          },
-          networkIn: 42,
-          networkOut: 42,
-          keyPair: 'key',
-          type: 'type',
-          tags: {
-            Name: 'name'
+    value: [
+      {
+        account: '420',
+        reportDate: Moment().toISOString(),
+        instances: [
+          {
+            id: '42',
+            state: 'running',
+            region: 'us-west-1',
+            cpuAverage: 42,
+            cpuPeak: 42,
+            ioRead: {
+              internal: 42
+            },
+            ioWrite: {
+              internal: 42
+            },
+            networkIn: 42,
+            networkOut: 42,
+            keyPair: 'key',
+            type: 'type',
+            tags: {
+              Name: 'name'
+            }
           }
-        }
-      ]
-    }
+        ]
+      }
+    ]
   }
 };
 

--- a/src/containers/aws/ResourcesContainer.js
+++ b/src/containers/aws/ResourcesContainer.js
@@ -6,7 +6,6 @@ import Actions from '../../actions';
 import s3square from '../../assets/s3-square.png';
 
 const Panel = Components.Misc.Panel;
-const AccountSelector = Components.AWS.Accounts.AccountSelector;
 const VMs = Components.AWS.Resources.VMs;
 const Databases = Components.AWS.Resources.Databases;
 
@@ -19,14 +18,6 @@ export class ResourcesContainer extends Component {
             <img className="white-box-title-icon" src={s3square} alt="AWS square logo"/>
             Resources
           </h3>
-          <div className="inline-block pull-right">
-            Selected account :
-            <AccountSelector
-              account={this.props.account}
-              selectAccount={this.props.selectAccount}
-              idFromARN={true}
-            />
-          </div>
         </div>
         <VMs/>
         <Databases/>
@@ -35,21 +26,4 @@ export class ResourcesContainer extends Component {
   }
 }
 
-ResourcesContainer.propTypes = {
-  account: PropTypes.string,
-  selectAccount: PropTypes.func.isRequired,
-};
-
-/* istanbul ignore next */
-const mapStateToProps = ({aws}) => ({
-  account: aws.resources.account,
-});
-
-/* istanbul ignore next */
-const mapDispatchToProps = (dispatch) => ({
-  selectAccount: (accountId) => {
-    dispatch(Actions.AWS.Resources.selectAccount(accountId));
-  },
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(ResourcesContainer);
+export default ResourcesContainer;

--- a/src/containers/aws/ResourcesContainer.js
+++ b/src/containers/aws/ResourcesContainer.js
@@ -1,8 +1,5 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
 import Components from '../../components';
-import Actions from '../../actions';
 import s3square from '../../assets/s3-square.png';
 
 const Panel = Components.Misc.Panel;

--- a/src/containers/aws/__tests__/ResourcesContainer.js
+++ b/src/containers/aws/__tests__/ResourcesContainer.js
@@ -3,7 +3,6 @@ import { ResourcesContainer } from '../ResourcesContainer';
 import { shallow } from 'enzyme';
 import Components from "../../../components";
 
-const AccountSelector = Components.AWS.Accounts.AccountSelector;
 const Panel = Components.Misc.Panel;
 const VMs = Components.AWS.Resources.VMs;
 const Databases = Components.AWS.Resources.Databases;
@@ -24,12 +23,6 @@ describe('<ResourcesContainer />', () => {
     const wrapper = shallow(<ResourcesContainer {...props}/>);
     const panel = wrapper.find(Panel);
     expect(panel.length).toBe(1);
-  });
-
-  it('renders an <AccountSelector /> component', () => {
-    const wrapper = shallow(<ResourcesContainer {...props}/>);
-    const selector = wrapper.find(AccountSelector);
-    expect(selector.length).toBe(1);
   });
 
   it('renders an <VMs /> component', () => {

--- a/src/sagas/aws/resourcesSaga.js
+++ b/src/sagas/aws/resourcesSaga.js
@@ -1,12 +1,13 @@
 import { put, call } from 'redux-saga/effects';
 import API from '../../api';
 import Constants from '../../constants';
-import { getToken } from "../misc";
+import {getAWSAccounts, getToken} from "../misc";
 
-export function* getEC2ReportSaga({ accountId }) {
+export function* getEC2ReportSaga() {
   try {
     const token = yield getToken();
-    const res = yield call(API.AWS.Resources.getEC2, token, accountId);
+    const accounts = yield getAWSAccounts();
+    const res = yield call(API.AWS.Resources.getEC2, token, accounts);
     if (res.success && res.hasOwnProperty("data") && !res.data.hasOwnProperty("error"))
       yield put({ type: Constants.AWS_RESOURCES_GET_EC2_SUCCESS, report: res.data });
     else if (res.success && res.data.hasOwnProperty("error"))
@@ -18,11 +19,11 @@ export function* getEC2ReportSaga({ accountId }) {
   }
 }
 
-export function* getRDSReportSaga({ accountId }) {
+export function* getRDSReportSaga() {
   try {
     const token = yield getToken();
-    const res = yield call(API.AWS.Resources.getRDS, token, accountId);
-    console.log(res);
+    const accounts = yield getAWSAccounts();
+    const res = yield call(API.AWS.Resources.getRDS, token, accounts);
     if (res.success && res.hasOwnProperty("data") && !res.data.hasOwnProperty("error"))
       yield put({ type: Constants.AWS_RESOURCES_GET_RDS_SUCCESS, report: res.data });
     else if (res.success && res.data.hasOwnProperty("error"))

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -583,3 +583,94 @@ h4.no-data {
 .tags-item:last-child {
     border-bottom: none;
 }
+
+/* Resources */
+.resources h3.white-box-title {
+    margin-bottom: 10px;
+}
+
+.resources i {
+    color: #4885ed;
+}
+
+.resources .wrapper {
+    display: inline-block;
+    margin: 0 10px;
+}
+
+.resources .popover-trigger i {
+    color: #000000;
+    font-size: 0.75em;
+}
+
+.rt-th input {
+    border: none;
+    height: 100%;
+    color: #666;
+    font-size: 1.2em;
+    text-align: center;
+    border-bottom: 1px solid #aaa;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+    border-radius: 5px;
+}
+
+.rt-th select {
+    border: none;
+    margin: 0;
+    color: #666;
+}
+
+.cpu-stats,
+.cpu-stats .wrapper,
+.cpu-stats .wrapper .popover-trigger {
+    width: 100%;
+    height: 100%;
+}
+
+.cpu-stats .wrapper {
+    margin: 0;
+}
+
+.vms .rt-tr-group .rt-td:last-child {
+    text-align: center;
+}
+
+.rt-td .wrapper .popover-trigger i {
+    color: #4885ed;
+    font-size: 1.5em;
+}
+
+.rt-td .wrapper .popover-trigger i.red {
+    color: #d6413b;
+}
+
+.rt-td .wrapper .popover-trigger i.orange {
+    color: #ff9800;
+}
+
+.rt-td .wrapper .popover-trigger i.green {
+    color: #4caf50;
+}
+
+.rt-td .wrapper .popover-trigger i.grey {
+    color: #565656;
+}
+
+.rt-td .wrapper .popover-trigger i.disabled {
+    color: #cccccc;
+    font-size: 1.5em;
+}
+
+.tags-list {
+    padding: 10px;
+    border: 1px solid #ddd;
+}
+
+.tags-item {
+    padding: 10px 5px;
+    border-bottom: 1px solid #ddd;
+}
+
+.tags-item:last-child {
+    border-bottom: none;
+}


### PR DESCRIPTION
This PR will add multi-accounts supports for Resources List.

I removed the account selector and use the selected accounts in Navigation menu to request data from API.