### PR TITLE
Add Total line for Cost Table

### DIFF
--- a/src/common/__tests__/formatters.js
+++ b/src/common/__tests__/formatters.js
@@ -357,7 +357,18 @@ describe('Formatters', () => {
           }, {
             key: "product2",
             date1: {cost: 21, variation: 2.1}
-          }]
+          }],
+          total: {
+            key: "Total",
+            date1: {
+              cost: 42 + 21,
+              variation: 0
+            },
+            date2: {
+              cost: 84,
+              variation: (84 - 42 - 21) / (42 + 21) * 100
+            }
+          }
         };
         expect(transformCostDifferentiator(data)).toEqual(output);
       });
@@ -389,7 +400,18 @@ describe('Formatters', () => {
           }, {
             key: "product2",
             date1: {cost: 21, variation: 2.1}
-          }]
+          }],
+          total: {
+            key: "Total",
+            date1: {
+              cost: 21,
+              variation: 0
+            },
+            date2: {
+              cost: 0,
+              variation: (0 - 21) / 21 * 100
+            }
+          }
         };
         expect(transformCostDifferentiator(data)).toEqual(output);
       });

--- a/src/common/formatters.js
+++ b/src/common/formatters.js
@@ -97,7 +97,20 @@ export const costBreakdown = {
         ...itemValues
       };
     });
-    return {dates, values};
+    let previous = null;
+    const total = {
+      key: "Total"
+    };
+    dates.forEach((date) => {
+      let cost = 0;
+      values.forEach((value) => {
+        cost += value[date].cost;
+      });
+      const variation = (previous != null && previous !== 0 ? (cost - previous) / previous * 100 : 0);
+      previous = cost;
+      total[date] = {cost, variation};
+    });
+    return {dates, values, total};
   }
 };
 

--- a/src/common/formatters.js
+++ b/src/common/formatters.js
@@ -101,10 +101,12 @@ export const costBreakdown = {
     const total = {
       key: "Total"
     };
+    console.log(values);
     dates.forEach((date) => {
+      console.log(date);
       let cost = 0;
       values.forEach((value) => {
-        cost += value[date].cost;
+        cost += (value.hasOwnProperty(date) ? value[date].cost : 0);
       });
       const variation = (previous != null && previous !== 0 ? (cost - previous) / previous * 100 : 0);
       previous = cost;

--- a/src/common/formatters.js
+++ b/src/common/formatters.js
@@ -101,9 +101,7 @@ export const costBreakdown = {
     const total = {
       key: "Total"
     };
-    console.log(values);
     dates.forEach((date) => {
-      console.log(date);
       let cost = 0;
       values.forEach((value) => {
         cost += (value.hasOwnProperty(date) ? value[date].cost : 0);

--- a/src/components/aws/costBreakdown/DifferentiatorChartComponent.js
+++ b/src/components/aws/costBreakdown/DifferentiatorChartComponent.js
@@ -15,13 +15,14 @@ class DifferentiatorChartComponent extends Component {
   };
 
   /* istanbul ignore next */
-  generateColumns(dates) {
+  generateColumns(dates, total) {
     return dates.map((date, index) => {
       let columns = [{
         Header: 'Cost',
         id: date + '.cost',
         accessor: row => row[date].cost,
-        Cell: row => (<span className="cost-cell">{formatPrice(row.value)}</span>)
+        Cell: row => (<span className="cost-cell">{formatPrice(row.value)}</span>),
+        Footer: (<strong>{formatPrice(total[date].cost)}</strong>)
       }];
       if (index > 0)
         columns.push({
@@ -29,6 +30,7 @@ class DifferentiatorChartComponent extends Component {
           id: date + '.variation',
           accessor: row => row[date].variation,
           Cell: row => (<span className="percentvariation-cell">{formatPercent(row.value)}</span>),
+          Footer: (<strong>{formatPercent(total[date].variation)}</strong>),
           sortMethod: (a, b) => (Math.abs(a) > Math.abs(b) ? 1 : -1)
         });
       return ({
@@ -44,7 +46,7 @@ class DifferentiatorChartComponent extends Component {
     if (!datum)
       return (<h4 className="no-data">No data available for this timerange</h4>);
 
-    const dates = this.generateColumns(datum.dates);
+    const dates = this.generateColumns(datum.dates, datum.total);
 
     /* istanbul ignore next */
     return (
@@ -57,7 +59,8 @@ class DifferentiatorChartComponent extends Component {
             {
               Header: 'Name',
               accessor: 'key',
-              Cell: row => (<strong>{row.value}</strong>)
+              Cell: row => (<strong>{row.value}</strong>),
+              Footer: (<strong>Total</strong>)
             },
             ...dates
           ]}


### PR DESCRIPTION
This PR adds a line in Cost Table with total cost and cost variation for each period.
This line is in the Table Footer, to be displayed in every Table page.