### PR TITLE
Add Availability Zone in Filters & Fix region with empty name

### DIFF
--- a/src/common/formatters.js
+++ b/src/common/formatters.js
@@ -72,7 +72,7 @@ export const costBreakdown = {
     if (!data.hasOwnProperty(filter))
       return [];
     return Object.keys(data[filter]).map((id) => ({
-      key: id,
+      key: (id.length ? id : `No ${filter}`),
       value: data[filter][id]
     }));
   },

--- a/src/components/aws/costBreakdown/ChartComponent.js
+++ b/src/components/aws/costBreakdown/ChartComponent.js
@@ -17,7 +17,8 @@ const getFilters = (total) => {
   let filters = {
     account: "Account",
     product: "Product",
-    region: "Region"
+    region: "Region",
+    availabilityzone: "Availability zone"
   };
   if (total)
     filters.all = "Total";


### PR DESCRIPTION
This PR will add "Availability Zone" in Filters for Cost Breakdown (Bar Charts & Pie Charts) and also fix issue with regions/availability zone without a name (They will be displayed as "No region" or "No availability zone", based on your filter).