### PR TITLE
Fix Timeout & Prefill conflict on Login Form

### DIFF
--- a/src/components/auth/FormComponent.js
+++ b/src/components/auth/FormComponent.js
@@ -20,7 +20,7 @@ export class FormComponent extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      email: (this.props.match && this.props.match.params && this.props.match.params.prefill) ? decodeURIComponent(this.props.match.params.prefill) : '',
+      email: (this.props.match && this.props.match.params && this.props.match.params.prefill && this.props.match.params.prefill !== "timeout") ? decodeURIComponent(this.props.match.params.prefill) : '',
       password: '',
       passwordConfirmation: '',
     }

--- a/src/containers/auth/LoginContainer.js
+++ b/src/containers/auth/LoginContainer.js
@@ -18,7 +18,6 @@ export class LoginContainer extends Component {
     this.props.clear();
   }
 
-
   render() {
     const awstoken = (this.props.match.params.hasOwnProperty("awstoken") ? this.props.match.params.awstoken : "");
     if (this.props.token)
@@ -28,7 +27,7 @@ export class LoginContainer extends Component {
       submit={this.props.login}
       loginStatus={this.props.loginStatus}
       registrationStatus={this.props.registrationStatus}
-      timeout={(this.props.match.path.endsWith("timeout"))}
+      timeout={(this.props.match.params && this.props.match.params.prefill && this.props.match.params.prefill === "timeout")}
       />);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -51,8 +51,7 @@ ReactDOM.render((
           <div>
             <Route exact path="/" component={IndexRedirect}/>
             <Route path="/login" component={Containers.Auth.Login} exact/>
-            <Route path="/login/timeout" component={Containers.Auth.Login} exact/>
-            <Route path="/login/:prefill" component={Containers.Auth.Login} exact/>
+            <Route path="/login/:prefill" component={Containers.Auth.Login}/>
             <Route path="/login/aws/:awstoken" component={Containers.Auth.Login}/>
             <Route path="/register" component={Containers.Auth.Register} exact/>
             <Route path="/register/aws/:awstoken" component={Containers.Auth.Register}/>


### PR DESCRIPTION
This PR fixes conflict with routes `/login/timeout` & `/login/:prefill`.

Previously, `/login/timeout` was matching its own route but also`/login/:prefill` (with `timeout` as a prefill).

Now, I removed `/login/timeout` route and added conditions into `LoginContainer` & `Login Form` to avoid confusion between these two routes.