### PR TITLE
TRAC-992 Add potential savings to top bar on HL view

### DIFF
--- a/src/components/high-level/HighLevelComponent.js
+++ b/src/components/high-level/HighLevelComponent.js
@@ -101,6 +101,7 @@ export class HighLevelComponent extends Component {
             costs={this.props.costs.values}
             date={this.props.dates.startDate}
             currentInterval={this.state.currentInterval}
+            unused={this.props.unused}
           />;
           topSpendings = <TopSpendings
             costs={this.props.costs.values}

--- a/src/components/high-level/SummaryComponent.js
+++ b/src/components/high-level/SummaryComponent.js
@@ -15,6 +15,18 @@ class SummaryComponent extends Component {
     return res;
   }
 
+  getPotentialsSavings(unused ) {
+    let res = 0;
+
+    if (unused.ec2 && unused.ec2.status && unused.ec2.values) {
+        for (let i = 0; i < unused.ec2.values.length; i++) {
+            const element = unused.ec2.values[i];
+            res += element.cost;
+        }
+    }
+    return res;
+  }
+
   render() {
     let message;
     let monthCost;
@@ -87,12 +99,39 @@ class SummaryComponent extends Component {
       } else
         message = (<h4 className="no-data">No data available for this timerange</h4>);
     }
+
+    let savingsElement
+    if (this.props.unused
+      && this.props.unused.ec2
+      && this.props.unused.ec2.status) {
+      let savings = this.getPotentialsSavings(this.props.unused);
+
+      savingsElement = (
+        <div className="hl-card">
+          <ul className="in-col">
+            <li>
+              <i className="fa fa-power-off card-icon blue-color"/>
+            </li>
+            <li>
+              <h3 className={`no-margin no-padding font-light`}>
+                {formatPrice(savings.toFixed(2))}
+              </h3>
+            </li>
+          </ul>
+          <h4 className="card-label p-l-10 m-b-0">
+            potential savings
+          </h4>
+        </div>
+      );
+    }
+
     return (
       <div className="col-md-12">
         <div className="white-box">
           {message}
           {monthCost}
           {variation}
+          {savingsElement}
           <div className="clearfix"/>
         </div>
       </div>

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -385,7 +385,7 @@ h4.no-data {
 /* High Level views */
 
 .hl-card {
-    width: 48%;
+    width: 31%;
     float: left;
     text-align: center;
     margin-top: 10px;


### PR DESCRIPTION
This adds the potential savings total to the top bar in the HL view.

![screenshot 2018-10-12 at 12 36 54](https://user-images.githubusercontent.com/3480526/46864725-8bd17900-ce1b-11e8-97b8-6e40ee8162e0.png)
