### PR TITLE
TRAC-818 Limit account selector height

### DIFF
--- a/src/styles/Navigation.css
+++ b/src/styles/Navigation.css
@@ -191,6 +191,7 @@ div.dropdown-trigger:hover  .dropdown-menu {
 
 #account-selection {
     height: auto;
+    max-height: 210px;
     overflow-y: scroll;
     border-top: 1px solid #ddd;
     border-bottom: 1px solid #ddd;


### PR DESCRIPTION
This limits the height of the account selector to avoid hiding menu items when a lot of accounts are setup.