### PR TITLE
TRAC-969 Display N/A + Tooltip in Resources view when cost is not available

### DIFF
--- a/src/components/aws/resources/DatabasesComponent.js
+++ b/src/components/aws/resources/DatabasesComponent.js
@@ -162,7 +162,16 @@ export class DatabasesComponent extends Component {
             id: 'cost',
             accessor: d => d.cost || 0,
             filterable: false,
-            Cell: row => (formatPrice(row.value))
+            Cell: row => {
+              if (row.value === 0 && Object.keys(row.original.costDetail).length === 0) {
+                return <span>
+                  N/A
+                  <Tooltip tooltip='Cost data are unavailable for this timerange. Please check again later.' info triggerStyle={{ fontSize: '0.9em', color: 'inherit' }} />
+                </span>;
+              } else {
+                return (formatPrice(row.value));
+              }
+            }
           },
           {
             Header: 'Engine',

--- a/src/components/aws/resources/VMsComponent.js
+++ b/src/components/aws/resources/VMsComponent.js
@@ -241,7 +241,16 @@ export class VMsComponent extends Component {
             Header: 'Cost',
             accessor: 'cost',
             filterable: false,
-            Cell: row => (formatPrice(row.value))
+            Cell: row => {
+              if (row.value === 0 && Object.keys(row.original.costDetail).length === 0) {
+                return <span>
+                  N/A
+                  <Tooltip tooltip='Cost data are unavailable for this timerange. Please check again later.' info triggerStyle={{ fontSize: '0.9em', color: 'inherit' }} />
+                </span>;
+              } else {
+                return (formatPrice(row.value));
+              }
+            }
           },
           {
             Header: 'Purchasing Option',


### PR DESCRIPTION
This displays N/A + a tooltip when the cost is not available in the resources view instead of $0.

![screenshot 2018-10-26 at 13 16 11](https://user-images.githubusercontent.com/3480526/47563834-5b153780-d923-11e8-8279-97d6fce2a73c.png)
