### PR TITLE
TRAC-819 Fix timezone issue

### DIFF
--- a/src/components/aws/costBreakdown/BarChartComponent.js
+++ b/src/components/aws/costBreakdown/BarChartComponent.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import * as d3 from 'd3';
 import NVD3Chart from 'react-nvd3';
@@ -8,9 +9,12 @@ import ChartsColors from "../../../styles/ChartsColors";
 
 const transformProductsBarChart = costBreakdown.transformProductsBarChart;
 
+// For timezones compensation
+const timeOffset = new Date().getTimezoneOffset();
+
 /* istanbul ignore next */
 const context = {
-  formatXAxis: (d) => (d3.time.format('%x')(new Date(d))),
+  formatXAxis: (d) => (moment(d).format('YYYY-MM-DD')),
   formatYAxis: (d) => ('$' + d3.format(',.2f')(d)),
 };
 
@@ -30,8 +34,8 @@ const yAxis = {
 
 /* istanbul ignore next */
 const formatX = (d) => {
-  const date = new Date(d[0]);
-  return date.getTime();
+  const date = moment(d[0]).add(timeOffset, 'm');
+  return date.valueOf();
 };
 
 /* istanbul ignore next */

--- a/src/components/events/EventPanel.js
+++ b/src/components/events/EventPanel.js
@@ -4,8 +4,12 @@ import PropTypes from 'prop-types';
 import NVD3Chart from 'react-nvd3';
 import * as d3 from 'd3';
 
+// For timezones compensation
+const timeOffset = new Date().getTimezoneOffset();
+
+
 const context = {
-    formatXAxis: (d) => (d3.time.format('%x')(new Date(d))),
+    formatXAxis: (d) => (moment(d).format('YYYY-MM-DD')),
     formatYAxis: (d) => ('$' + d3.format(',.2f')(d)),
   };
   
@@ -25,10 +29,10 @@ const context = {
   
   /* istanbul ignore next */
   const formatX = (d) => {
-    const date = new Date(d[0]);
-    return date.getTime();
+    const date = moment(d[0]).add(timeOffset, 'm');
+    return date.valueOf();
   };
-  
+    
   /* istanbul ignore next */
   const formatY = (d) => (d[1]);
   
@@ -118,9 +122,9 @@ class EventPanel extends Component {
                     &nbsp;
                     <span className={this.getBadgeClasses(anomalyLevel)}>{badgeLabels[anomalyLevel]}</span>
                 </h5>
-                <h5 className="inline-block pull-right">{moment(abnormalElement.date).format("ddd, MMM Do Y")}</h5>
+                <h5 className="inline-block pull-right">{moment(abnormalElement.date).add(timeOffset, 'm').format("ddd, MMM Do Y")}</h5>
                 <div className="clearfix"></div>
-                <p>On {moment(abnormalElement.date).format("ddd, MMM Do Y")}, <strong>{service.length ? service : "Unknown service"}</strong> exceeded the maximum expected cost for this service by <strong>${exceededCost}</strong></p>
+                <p>On {moment(abnormalElement.date).add(timeOffset, 'm').format("ddd, MMM Do Y")}, <strong>{service.length ? service : "Unknown service"}</strong> exceeded the maximum expected cost for this service by <strong>${exceededCost}</strong></p>
                 <hr />
                 <NVD3Chart
                     id="barChart"


### PR DESCRIPTION
This fixes the timezone issues we had on some charts.
To test this just change your OS timezone and refresh the web page.

The issue came from an offset between the timerange the UI requested to the API and the result the API sent.
For instance if a user in California would request a Oct 1st to Oct 31st timerange. The effective date sent to the API would be Oct 1st 7AM  to Nov1st 7AM because our time are UTC based. This is correct.
However the API would send daily interval and would thus send back a dataload with the first item being at Oct 1st midnight anyway. So that would make some display errors on the X axis on some charts.

This adds an offset to the concerned charts to make the axis right in any timezone.