### PR TITLE
Accounts Selector & Status

### DIFF
--- a/src/api/aws/accounts.js
+++ b/src/api/aws/accounts.js
@@ -55,3 +55,7 @@ export const editAccountViewer = (sharedID, permissionLevel, token) => {
 export const deleteAccountViewer = (sharedID, token) => {
   return call(`/user/share?share-id=${sharedID}`, 'DELETE', null, token);
 };
+
+export const getAccountsStatus = (token) => {
+  return call('/aws/status', 'GET', null, token);
+};

--- a/src/common/awsAccountStatus.js
+++ b/src/common/awsAccountStatus.js
@@ -1,0 +1,70 @@
+import React from "react";
+
+const errors = {
+  "error": 0,
+  "not_started": 1,
+  "in_progress": 2,
+  "ok": 3
+};
+
+const getBadge = (status) => {
+  switch (status.value) {
+    case "error":
+      return (<i className="fa account-badge fa-times-circle"/>);
+    case "not_started":
+    case "in_progress":
+      return (<i className="fa account-badge fa-clock-o"/>);
+    case "ok":
+      return (<i className="fa account-badge fa-check-circle"/>);
+    default:
+      return null;
+  }
+};
+
+const getInformationBanner = (status) => {
+  switch (status.value) {
+    case "error":
+      return (<div className="alert alert-danger account-badge-information-banner">Import failed, please check your bills locations.</div>);
+    case "not_started":
+    case "in_progress":
+      return (<div className="alert alert-warning account-badge-information-banner">Import may take up to 24 hours, please wait.</div>);
+    case "ok":
+    default:
+      return null;
+  }
+};
+
+const getAWSAccountStatus = (account) => {
+  const status = {
+    value: "ok",
+    details: []
+  };
+  if (account.status) {
+    status.value = account.status.value;
+    status.details.push("Account : " + account.status.detail);
+  }
+  let hasBillRepositoryError = false;
+  getBillRepositoriesStatuses(account.billRepositories).forEach((billRepository) => {
+    if (billRepository) {
+      if (errors[status.value] > errors[billRepository.value])
+        status.value = billRepository.value;
+      if (billRepository.value === "error" && !hasBillRepositoryError) {
+        status.details.push("Bill locations : See in dedicated section for more details");
+        hasBillRepositoryError = true;
+      }
+    }
+  });
+  return status;
+};
+
+const getBillRepositoriesStatuses = (billRepositories) => {
+  if (billRepositories)
+    return billRepositories.map((billRepository) => (billRepository.status));
+  return [];
+};
+
+export default {
+  getAWSAccountStatus,
+  getBadge,
+  getInformationBanner
+};

--- a/src/components/aws/accounts/ListComponent.js
+++ b/src/components/aws/accounts/ListComponent.js
@@ -8,6 +8,7 @@ import Misc from '../../misc';
 import Form from './FormComponent';
 import Bills from './bills';
 import TeamSharing from './teamSharing';
+import Status from '../../../common/awsAccountStatus';
 
 const Tooltip = Misc.Popover;
 const DeleteConfirmation = Misc.DeleteConfirmation;
@@ -18,10 +19,6 @@ export class Item extends Component {
     super(props);
     this.editAccount = this.editAccount.bind(this);
     this.deleteAccount = this.deleteAccount.bind(this);
-    this.hasError = this.hasError.bind(this);
-    this.hasNextPending = this.hasNextPending.bind(this);
-    this.getAccountBadge = this.getAccountBadge.bind(this);
-    this.getInformationBanner = this.getInformationBanner.bind(this);
   }
 
   editAccount = (body) => {
@@ -34,51 +31,21 @@ export class Item extends Component {
     this.props.accountActions.delete(this.props.account.id);
   };
 
-  hasError = () => {
-    if (this.props.account.payer) {
-      let result = !this.props.account.billRepositories.length;
-      this.props.account.billRepositories.forEach((billRepository) => {
-        if (billRepository.error !== "")
-          result = true;
-      });
-      return result;  
-    }
-    return false;
-  };
-
-  hasNextPending = () => {
-    let result = false;
-    this.props.account.billRepositories.forEach((billRepository) => {
-      if (billRepository.nextPending)
-        result = true;
-    });
-    return result;
-  };
-
-  getAccountBadge = () => {
-    if (this.hasError())
-      return (<i className="fa account-badge fa-times-circle"/>);
-    else if (this.hasNextPending())
-      return (<i className="fa account-badge fa-clock-o"/>);
-    return (<i className="fa account-badge fa-check-circle"/>);
-  };
-
-  getInformationBanner = () => {
-    if (this.hasError())
-      return (<ListItem divider className="account-alert"><div className="alert alert-danger account-badge-information-banner">Import failed, please check your bills locations.</div></ListItem>);
-    else if (this.hasNextPending())
-      return (<ListItem divider className="account-alert"><div className="alert alert-warning account-badge-information-banner">Import may take up to 24 hours, please wait.</div></ListItem>);
-    return null;
-  };
-
   render() {
-    const infoBanner = this.getInformationBanner();
+    const status = Status.getAWSAccountStatus(this.props.account);
+    const accountBadge = Status.getBadge(status);
+    const infoBanner = Status.getInformationBanner(status);
+    const formattedInfoBanner = (infoBanner ? (
+      <ListItem divider className="account-alert">
+        {infoBanner}
+      </ListItem>
+    ) : null)
     return (
       <div>
 
         <ListItem divider={(infoBanner === null)} className="account-item">
 
-          {this.getAccountBadge()}
+          {accountBadge}
 
           <ListItemText
             disableTypography
@@ -122,7 +89,7 @@ export class Item extends Component {
 
         </ListItem>
 
-        {infoBanner}
+        {formattedInfoBanner}
 
       </div>
     );
@@ -137,13 +104,21 @@ Item.propTypes = {
     pretty: PropTypes.string,
     permissionLevel: PropTypes.number,
     payer: PropTypes.bool.isRequired,
+    status: PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      detail: PropTypes.string.isRequired,
+    }),
     billRepositories: PropTypes.arrayOf(
       PropTypes.shape({
         error: PropTypes.string.isRequired,
         accountOwner: PropTypes.bool,
         nextPending: PropTypes.bool.isRequired,
         bucket: PropTypes.string.isRequired,
-        prefix: PropTypes.string.isRequired
+        prefix: PropTypes.string.isRequired,
+        status: PropTypes.shape({
+          value: PropTypes.string.isRequired,
+          detail: PropTypes.string.isRequired,
+        })
       })
     ),
   }),

--- a/src/components/aws/accounts/__tests__/ListComponent.js
+++ b/src/components/aws/accounts/__tests__/ListComponent.js
@@ -38,7 +38,11 @@ const accountWithBills = {
       error: "access denied",
       nextPending: true,
       bucket: "another-billing-bucket",
-      prefix: "another-prefix"
+      prefix: "another-prefix",
+      status: {
+        value: "error",
+        detail: "access denied"
+      }
     },
   ],
 };
@@ -48,6 +52,7 @@ const accountWithRightBills = {
   userId: 42,
   roleArn: "arn:aws:iam::000000000001:role/TEST_ROLE",
   pretty: "Name",
+  payer: true,
   billRepositories: [
     {
       error: "",
@@ -134,11 +139,6 @@ describe('<Item />', () => {
     account: accountWithBills
   };
 
-  const propsWithoutBills = {
-    ...props,
-    account: accountWithoutBills
-  };
-
   beforeEach(() => {
     jest.resetAllMocks();
   });
@@ -155,9 +155,6 @@ describe('<Item />', () => {
   });
 
   it('renders two <ListItem/> component with one for error message ', () => {
-    const wrapper = shallow(<Item {...propsWithoutBills}/>);
-    const item = wrapper.find(ListItem);
-    expect(item.length).toBe(2);
     const wrapperBis = shallow(<Item {...propsWithErrorInBills}/>);
     const itemBis = wrapperBis.find(ListItem);
     expect(itemBis.length).toBe(2);

--- a/src/components/aws/accounts/index.js
+++ b/src/components/aws/accounts/index.js
@@ -7,6 +7,9 @@ import Wizard from './WizardComponent';
 import SelectedIndicator from './SelectedIndicatorComponent';
 import StatusBadges from './StatusBadgesComponent';
 import Users from './teamSharing';
+import Status from './status';
+
+const AccountsStatus = Status.AccountsStatus;
 
 export default {
   Form,
@@ -18,4 +21,5 @@ export default {
   Wizard,
   StatusBadges,
   Users,
+  AccountsStatus
 };

--- a/src/components/aws/accounts/status/AccountsStatusComponent.js
+++ b/src/components/aws/accounts/status/AccountsStatusComponent.js
@@ -1,0 +1,214 @@
+import React, { Component } from 'react';
+import {Redirect} from "react-router-dom";
+import { connect } from 'react-redux';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogActions from '@material-ui/core/DialogActions';
+import List from '@material-ui/core/List';
+import PropTypes from 'prop-types';
+import Actions from "../../../../actions/index";
+import Spinner from 'react-spinkit';
+import Item from './ItemComponent';
+
+const styles = {
+  badge : {
+    fontSize: '14px',
+    fontWeight: '500',
+    cursor: "pointer"
+  },
+  icon: {
+    fontSize: '16px',
+  }
+};
+
+const schedulerDuration = 1000 * 60 * 30; // 30 minutes
+
+// Accounts Status Component for AWS Account status
+class AccountsStatusComponent extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: false,
+      goToSetup: false,
+    };
+    this.openDialog = this.openDialog.bind(this);
+    this.closeDialog = this.closeDialog.bind(this);
+    this.setupAccounts = this.setupAccounts.bind(this);
+    this.scheduler = null;
+  }
+
+  componentDidMount() {
+    this.props.getAccounts();
+    this.setScheduler();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    clearTimeout(this.scheduler);
+    if (this.props.accounts !== nextProps.accounts && nextProps.accounts.status && nextProps.accounts.hasOwnProperty("values"))
+      this.setScheduler();
+  }
+
+  setScheduler() {
+    this.scheduler = setTimeout(() => {
+      this.props.getAccounts();
+    }, schedulerDuration);
+  }
+
+  openDialog = (e) => {
+    e.preventDefault();
+    this.setState({open: true});
+  };
+
+  closeDialog = (e) => {
+    e.preventDefault();
+    this.setState({
+      open: false,
+    });
+  };
+
+  setupAccounts = (e) => {
+    e.preventDefault();
+    this.setState({
+      open: false,
+      goToSetup: true,
+    });
+  };
+
+  getText = () => {
+    const error = (this.props.accounts.error ? ` (${this.props.accounts.error.message})` : '');
+
+    if (!this.props.accounts.status)
+      return null;
+    if (this.props.accounts.status && (!this.props.accounts.values || !this.props.accounts.values.length || error))
+      return `No accounts ${error}`;
+    if (this.props.selection.length === 0 || this.props.accounts.values.length === this.props.selection.length)
+      return `Displaying All accounts`;
+    if (this.props.selection.length === 1)
+      return `Displaying ${this.props.selection[0].pretty}`;
+    return `Displaying ${this.props.selection.length} accounts`;
+  };
+
+  render() {
+    if (this.state.goToSetup) {
+      this.setState({goToSetup: false});
+      return (<Redirect to="/app/setup"/>);
+    }
+
+    const isSelected = (item) => (this.props.selection.find((value) => (value.id === item.id)) !== undefined);
+
+    const loading = (!this.props.accounts.status ? (<Spinner className="spinner" name='circle'/>) : null);
+
+    const error = (this.props.accounts.error ? ` (${this.props.accounts.error.message})` : null);
+    const noAccounts = (this.props.accounts.status && (!this.props.accounts.values || !this.props.accounts.values.length || error) ? <div className="alert alert-warning" role="alert">No account available{error}</div> : "");
+
+    const accounts = (this.props.accounts.status && this.props.accounts.values && this.props.accounts.values.length ? (
+      this.props.accounts.values.map((account, index) => (
+        <Item
+          key={index}
+          account={account}
+          select={this.props.select}
+          isSelected={isSelected(account)}
+        />
+      ))
+    ) : null);
+
+    return (
+      <div>
+
+        <span className="badge" onClick={this.openDialog} style={styles.badge}>
+          <span><i className="fa fa-amazon" style={styles.icon}/>&nbsp;&nbsp;</span>
+          {this.getText()}
+        </span>
+
+        <Dialog open={this.state.open} fullWidth>
+
+          <DialogTitle disableTypography>
+            <h1>AWS Accounts</h1>
+          </DialogTitle>
+
+          <DialogContent>
+
+            <List disablePadding className="accounts-list">
+              {loading}
+              {noAccounts}
+              {accounts}
+            </List>
+
+            <DialogActions>
+
+              <button className="btn btn-default pull-left" onClick={this.setupAccounts}>
+                Setup Accounts
+              </button>
+
+
+              <button className="btn btn-default pull-left" onClick={this.closeDialog}>
+                Close
+              </button>
+
+            </DialogActions>
+
+          </DialogContent>
+
+        </Dialog>
+      </div>
+    );
+  }
+
+}
+
+AccountsStatusComponent.propTypes = {
+  accounts: PropTypes.shape({
+    status: PropTypes.bool.isRequired,
+    error: PropTypes.instanceOf(Error),
+    values: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number.isRequired,
+        roleArn: PropTypes.string.isRequired,
+        pretty: PropTypes.string,
+        permissionLevel: PropTypes.number,
+        payer: PropTypes.bool.isRequired,
+        billRepositories: PropTypes.arrayOf(
+          PropTypes.shape({
+            error: PropTypes.string.isRequired,
+            nextPending: PropTypes.bool.isRequired,
+            bucket: PropTypes.string.isRequired,
+            prefix: PropTypes.string.isRequired
+          })
+        ),
+      })
+    ),
+  }),
+  selection: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      roleArn: PropTypes.string.isRequired,
+      pretty: PropTypes.string,
+    })
+  ),
+  select: PropTypes.func.isRequired,
+  clear: PropTypes.func.isRequired,
+  getAccounts: PropTypes.func.isRequired
+};
+
+/* istanbul ignore next */
+const mapStateToProps = ({aws}) => ({
+  accounts: aws.accounts.all,
+  selection: aws.accounts.selection,
+});
+
+/* istanbul ignore next */
+const mapDispatchToProps = (dispatch) => ({
+  getAccounts: () => {
+    dispatch(Actions.AWS.Accounts.getAccounts());
+  },
+  select: (account) => {
+    dispatch(Actions.AWS.Accounts.selectAccount(account));
+  },
+  clear: () => {
+    dispatch(Actions.AWS.Accounts.clearAccounts());
+  }
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(AccountsStatusComponent);

--- a/src/components/aws/accounts/status/ItemComponent.js
+++ b/src/components/aws/accounts/status/ItemComponent.js
@@ -1,0 +1,102 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import ListItem from "@material-ui/core/ListItem/ListItem";
+import ListItemText from "@material-ui/core/ListItemText/ListItemText";
+import Checkbox from "@material-ui/core/Checkbox/Checkbox";
+import Status from "../../../../common/awsAccountStatus";
+
+class Item extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: false
+    };
+    this.handleClick = this.handleClick.bind(this);
+    this.selectAccount = this.selectAccount.bind(this);
+  }
+
+  handleClick = () => {
+    this.setState(state => ({ open: !state.open }));
+  };
+
+  selectAccount = (e) => {
+    e.preventDefault();
+    this.props.select(this.props.account);
+  };
+
+  render() {
+    const status = Status.getAWSAccountStatus(this.props.account);
+    const accountBadge = Status.getBadge(status);
+/*
+    const subaccounts = (this.props.account.hasOwnProperty("children") ? (
+      <Collapse in={this.state.open} timeout="auto" unmountOnExit>
+        <List disablePadding className="account-item-details">
+          <ListItem>
+            <Checkbox
+              className={"checkbox " + (this.props.isSelected ? "selected" : "")}
+              checked={this.props.isSelected}
+              onChange={this.selectAccount}
+              disableRipple
+            />
+            <ListItemText inset primary="Subaccount 1" />
+          </ListItem>
+          <ListItem>
+            <Checkbox
+              className={"checkbox " + (this.props.isSelected ? "selected" : "")}
+              checked={this.props.isSelected}
+              onChange={this.selectAccount}
+              disableRipple
+            />
+            <ListItemText inset primary="Subaccount 2" />
+          </ListItem>
+        </List>
+      </Collapse>
+    ) : null);
+*/
+    return (
+      <div>
+        <ListItem className="account-item">
+          <Checkbox
+            className={"checkbox " + (this.props.isSelected ? "selected" : "")}
+            checked={this.props.isSelected}
+            onChange={this.selectAccount}
+            disableRipple
+          />
+          <ListItemText
+            disableTypography
+            className="account-name"
+            primary={this.props.account.pretty || this.props.account.roleArn}
+          />
+          <div className="actions">
+            {accountBadge}
+          </div>
+          {/*this.props.account.hasOwnProperty("children") ? (this.state.open ? <ExpandLess onClick={this.handleClick}/> : <ExpandMore onClick={this.handleClick}/>) : null*/}
+        </ListItem>
+      </div>
+    );
+  }
+
+}
+
+Item.propTypes = {
+  account: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    roleArn: PropTypes.string.isRequired,
+    pretty: PropTypes.string,
+    permissionLevel: PropTypes.number,
+    payer: PropTypes.bool.isRequired,
+    billRepositories: PropTypes.arrayOf(
+      PropTypes.shape({
+        error: PropTypes.string.isRequired,
+        nextPending: PropTypes.bool.isRequired,
+        bucket: PropTypes.string.isRequired,
+        prefix: PropTypes.string.isRequired
+      })
+    ),
+  }),
+  select: PropTypes.func.isRequired,
+  isSelected: PropTypes.bool
+};
+
+export default Item;

--- a/src/components/aws/accounts/status/index.js
+++ b/src/components/aws/accounts/status/index.js
@@ -1,0 +1,5 @@
+import AccountsStatus from './AccountsStatusComponent';
+
+export default {
+  AccountsStatus
+};

--- a/src/components/misc/NavbarHeader.js
+++ b/src/components/misc/NavbarHeader.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import Actions from '../../actions';
-import SelectedIndicator from '../aws/accounts/SelectedIndicatorComponent';
+import AccountsStatus from "../aws/accounts/status/AccountsStatusComponent";
 import '../../styles/Navigation.css';
 
 import logo from '../../assets/logo-white-coloured.png';
@@ -38,7 +38,9 @@ export class NavbarHeader extends Component {
               </div>
 
               <div className="top-right-part pull-right">
-                 <span style={{ display: 'inline-block', marginTop: '19px' }}><SelectedIndicator longVersion={true} icon={true} /></span>
+                 <span style={{ display: 'inline-block', marginTop: '19px' }}>
+                   <AccountsStatus/>
+                 </span>
                  <div className={'dropdown-trigger'}>
                    <button className="navbar-user-dropdown-toggle">
                      <span className="fa-stack red-color">

--- a/src/components/misc/Navigation.js
+++ b/src/components/misc/Navigation.js
@@ -4,8 +4,6 @@ import { NavLink, withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import Actions from '../../actions';
 import NavbarHeader from './NavbarHeader';
-import AccountSelector from '../aws/accounts/SelectorComponent';
-import SelectedIndicator from '../aws/accounts/SelectedIndicatorComponent';
 
 // Styling
 import '../../styles/Navigation.css';
@@ -19,21 +17,11 @@ export class Navigation extends Component {
     this.state = {
       userMenuExpanded: false,
     };
-    this.closeUserMenu = this.closeUserMenu.bind(this);
   }
 
   componentDidMount() {
     this.props.getData(this.props.eventsDates.startDate, this.props.eventsDates.endDate);
   }
-
-  toggleUserMenu() {
-    this.setState({ userMenuExpanded: !this.state.userMenuExpanded });
-  }
-
-  closeUserMenu = (e) => {
-    e.preventDefault();
-    this.setState({ userMenuExpanded: false });
-  };
 
   getAbnormals(data) {
     const res = [];
@@ -63,27 +51,17 @@ export class Navigation extends Component {
 
   render() {
 
-    let userMenu;
-    if (this.state.userMenuExpanded) {
-      userMenu = (
-        <div className="nav nav-second-level">
-          <AccountSelector/>
-        </div>
-      );
-    }
-
     let eventsBadge;
     if (this.props.events && this.props.events.status && this.props.events.values) {
       eventsBadge = <span className="menu-badge">{this.getEventsNumber(this.props.events.values)}</span>;
     }
-
 
     return(
       <div className="navigation">
 
         <NavbarHeader />
 
-        <div className="navbar-default sidebar animated fadeInLeft" role="navigation" onMouseLeave={this.closeUserMenu}>
+        <div className="navbar-default sidebar animated fadeInLeft" role="navigation">
           <div className="sidebar-head">
             <h3>
               <span className="open-close">
@@ -96,20 +74,6 @@ export class Navigation extends Component {
           </div>
 
           <ul className="nav flex-column" id="side-menu">
-            <li className="user-menu-item">
-              <button onClick={this.toggleUserMenu.bind(this)}>
-                <span className="fa-stack fa-lg red-color">
-                  <i className="fa fa-circle fa-stack-2x"></i>
-                  <i className="fa fa-amazon fa-stack-1x fa-inverse"></i>
-                </span>
-                <span className="hide-menu">
-                  <SelectedIndicator />
-                  <i className="fa fa-caret-right"/>
-                </span>
-              </button>
-              {userMenu || <hr className="m-b-0"/>}
-            </li>
-
             <li className="nav-item">
               <NavLink className="nav-link" exact to='/app' activeClassName="active">
                 <i className="menu-icon fa fa-home"/>

--- a/src/components/misc/__tests__/Navigation.js
+++ b/src/components/misc/__tests__/Navigation.js
@@ -19,18 +19,4 @@ describe('<Navigation />', () => {
     expect(wrapper.length).toEqual(1);
   });
 
-  it('renders without user menu', () => {
-    const wrapper = shallow(<Navigation {...props}/>);
-    expect(wrapper.state('userMenuExpanded')).toBe(false);
-  });
-
-  it('can expand and close user menu', () => {
-    const wrapper = shallow(<Navigation {...props}/>);
-    expect(wrapper.state('userMenuExpanded')).toBe(false);
-    wrapper.find('button').prop('onClick')();
-    expect(wrapper.state('userMenuExpanded')).toBe(true);
-    wrapper.instance().closeUserMenu({ preventDefault() {} });
-    expect(wrapper.state('userMenuExpanded')).toBe(false);
-  });
-
 });

--- a/src/reducers/aws/accounts/__tests__/allReducer.js
+++ b/src/reducers/aws/accounts/__tests__/allReducer.js
@@ -3,23 +3,24 @@ import Constants from '../../../../constants';
 
 const accounts = ["account1", "account2"];
 
-const defaultValue = {status: false};
+const initialValue = {status: false, values: []};
+const defaultValue = {status: false, values: accounts};
 const successValue = {status: true, values: accounts};
-const errorValue = {status: true, error: Error()};
+const errorValue = {status: true, error: Error(), values: accounts};
 const cleared = {status: true, values: []};
 
 describe("AllReducer", () => {
 
   it("handles initial state", () => {
-    expect(AllReducer(undefined, {})).toEqual(defaultValue);
+    expect(AllReducer(undefined, {})).toEqual(initialValue);
   });
 
   it("handles get accounts requested state", () => {
-    expect(AllReducer(null, { type: Constants.AWS_GET_ACCOUNTS })).toEqual(defaultValue);
+    expect(AllReducer(successValue, { type: Constants.AWS_GET_ACCOUNTS })).toEqual(defaultValue);
   });
 
   it("handles get accounts success state", () => {
-    expect(AllReducer(null, { type: Constants.AWS_GET_ACCOUNTS_SUCCESS, accounts })).toEqual(successValue);
+    expect(AllReducer(defaultValue, { type: Constants.AWS_GET_ACCOUNTS_SUCCESS, accounts })).toEqual(successValue);
   });
 
   it("handles get accounts fail state", () => {

--- a/src/reducers/aws/accounts/allReducer.js
+++ b/src/reducers/aws/accounts/allReducer.js
@@ -1,15 +1,15 @@
 import Constants from '../../../constants';
 
-const defaultValue = {status: false};
+const defaultValue = {status: false, values: []};
 
 export default (state=defaultValue, action) => {
   switch (action.type) {
     case Constants.AWS_GET_ACCOUNTS:
-      return defaultValue;
+      return {status: false, values: state.values};
     case Constants.AWS_GET_ACCOUNTS_SUCCESS:
       return {status: true, values: action.accounts};
     case Constants.AWS_GET_ACCOUNTS_ERROR:
-      return {status: true, error: action.error};
+      return {status: true, error: action.error, values: state.values};
     case Constants.AWS_GET_ACCOUNTS_CLEAR:
       return {status: true, values: []};
     default:

--- a/src/sagas/aws/__tests__/accountsSaga.js
+++ b/src/sagas/aws/__tests__/accountsSaga.js
@@ -30,7 +30,7 @@ describe("Accounts Saga", () => {
         .toEqual(getToken());
 
       expect(saga.next(token).value)
-        .toEqual(call(API.AWS.Accounts.getAccounts, token));
+        .toEqual(call(API.AWS.Accounts.getAccountsStatus, token));
 
       expect(saga.next(validResponse).value)
         .toEqual(put({ type: Constants.AWS_GET_ACCOUNTS_SUCCESS, accounts }));
@@ -47,7 +47,7 @@ describe("Accounts Saga", () => {
         .toEqual(getToken());
 
       expect(saga.next(token).value)
-        .toEqual(call(API.AWS.Accounts.getAccounts, token));
+        .toEqual(call(API.AWS.Accounts.getAccountsStatus, token));
 
       expect(saga.next(invalidResponse).value)
         .toEqual(put({ type: Constants.AWS_GET_ACCOUNTS_ERROR, error: Error("Error with request") }));
@@ -64,7 +64,7 @@ describe("Accounts Saga", () => {
         .toEqual(getToken());
 
       expect(saga.next(token).value)
-        .toEqual(call(API.AWS.Accounts.getAccounts, token));
+        .toEqual(call(API.AWS.Accounts.getAccountsStatus, token));
 
       expect(saga.next(noResponse).value)
         .toEqual(put({ type: Constants.AWS_GET_ACCOUNTS_ERROR, error: Error("Error with request") }));

--- a/src/sagas/aws/accountsSaga.js
+++ b/src/sagas/aws/accountsSaga.js
@@ -7,7 +7,7 @@ import Constants from '../../constants';
 export function* getAccountsSaga() {
   try {
     const token = yield getToken();
-    const res = yield call(API.AWS.Accounts.getAccounts, token);
+    const res = yield call(API.AWS.Accounts.getAccountsStatus, token);
     if (res.success === null) {
       yield put({type: Constants.LOGOUT_REQUEST});
       return;

--- a/src/styles/Navigation.css
+++ b/src/styles/Navigation.css
@@ -201,15 +201,18 @@ div.dropdown-trigger:hover  .dropdown-menu {
     padding-bottom: 0;
 }
 
-#account-selection .account-selection-item .checkbox {
+#account-selection .account-selection-item .checkbox,
+.accounts-list .checkbox {
     margin: 0;
 }
 
-#account-selection .account-selection-item input[type=checkbox] {
+#account-selection .account-selection-item input[type=checkbox],
+.accounts-list input[type=checkbox] {
     margin: 0;
 }
 
-#account-selection .account-selection-item .checkbox.selected svg path {
+#account-selection .account-selection-item .checkbox.selected svg path,
+.accounts-list .checkbox.selected svg path {
     fill: #4885ed;
 }
 
@@ -264,4 +267,15 @@ div.dropdown-trigger:hover  .dropdown-menu {
         margin-left: 60px;
         padding: 25px;
     }
+}
+
+/* Accounts status */
+.account-item-details {
+    margin-left: 25px !important;
+}
+
+
+.account-item-details ul li {
+    padding-top: 0;
+    padding-bottom: 0;
 }


### PR DESCRIPTION
This PR adds a new accounts selector :
- You can use it by clicking on "Displaying ..." on the Header.
- You can select accounts and see their status with the badge on the right.

In Setup view, badges are now based on the new status route.