### PR TITLE
UX update

### DIFF
--- a/src/common/awsAccountStatus.js
+++ b/src/common/awsAccountStatus.js
@@ -43,17 +43,22 @@ const getAWSAccountStatus = (account) => {
     status.value = account.status.value;
     status.details.push("Account : " + account.status.detail);
   }
-  let hasBillRepositoryError = false;
-  getBillRepositoriesStatuses(account.billRepositories).forEach((billRepository) => {
-    if (billRepository) {
-      if (errors[status.value] > errors[billRepository.value])
-        status.value = billRepository.value;
-      if (billRepository.value === "error" && !hasBillRepositoryError) {
-        status.details.push("Bill locations : See in dedicated section for more details");
-        hasBillRepositoryError = true;
+  if (account.billRepositories) {
+    let hasBillRepositoryError = false;
+    getBillRepositoriesStatuses(account.billRepositories).forEach((billRepository) => {
+      if (billRepository) {
+        if (errors[status.value] > errors[billRepository.value])
+          status.value = billRepository.value;
+        if (billRepository.value === "error" && !hasBillRepositoryError) {
+          status.details.push("Bill locations : See in dedicated section for more details");
+          hasBillRepositoryError = true;
+        }
       }
-    }
-  });
+    });
+  } else if (!account.billRepositories && account.payer) {
+    status.value = "error";
+    status.details.push("This account doesn't have any bills location set up");
+  }
   return status;
 };
 

--- a/src/components/aws/tags/ChartComponent.js
+++ b/src/components/aws/tags/ChartComponent.js
@@ -141,9 +141,19 @@ class ChartComponent extends Component {
     }
     else if (this.props.keys !== nextProps.keys && nextProps.keys.status
       && nextProps.keys.hasOwnProperty("values") && nextProps.keys.values.length)
-      nextProps.selectKey(nextProps.id, nextProps.keys.values[0]);
+      nextProps.selectKey(nextProps.id, this.selectDefaultKey(nextProps.keys.values));
     else if ((this.props.tag !== nextProps.tag && nextProps.tag !== "") || (this.props.filter !== nextProps.filter && nextProps.filter !== ""))
       nextProps.getValues(nextProps.id, nextProps.dates.startDate, nextProps.dates.endDate, nextProps.filter, nextProps.tag);
+  }
+
+  selectDefaultKey(keys) {
+    if (keys.indexOf("name") !== -1) {
+      return keys[keys.indexOf("name")];
+    } else if (keys.indexOf("Name") !== -1) {
+      return keys[keys.indexOf("Name")];
+    } else {
+      return keys[0];
+    }
   }
 
   render() {

--- a/src/components/events/EventPanel.js
+++ b/src/components/events/EventPanel.js
@@ -44,6 +44,14 @@ const context = {
 
 class EventPanel extends Component {
     formatDataForChart(data, service) {
+        data.sort((a, b) => {
+            if (a.date > b.date) {
+                return 1;
+            } else if (a.date < b.date) {
+                return -1;
+            }
+            return 0;
+        });
         const res = [
           {
             key: `${service.length ? service : "Unknown service"} cost`,

--- a/src/sagas/aws/accountsSaga.js
+++ b/src/sagas/aws/accountsSaga.js
@@ -12,9 +12,19 @@ export function* getAccountsSaga() {
       yield put({type: Constants.LOGOUT_REQUEST});
       return;
     }
-    if (res.success && res.hasOwnProperty("data"))
+    if (res.success && res.hasOwnProperty("data")) {
+      for (let i = 0; i < res.data.length; i++) {
+        const element = res.data[i];
+        if (element.subAccounts && element.subAccounts.length) {
+          yield element.subAccounts.sort((a , b) => {
+            if (a.pretty.toLowerCase() < b.pretty.toLowerCase()) return -1;
+            if (a.pretty.toLowerCase() > b.pretty.toLowerCase()) return 1;
+            return 0;      
+          })
+        }  
+      }
       yield put({ type: Constants.AWS_GET_ACCOUNTS_SUCCESS, accounts: res.data });
-    else if (res.success && res.hasOwnProperty("data") && res.data.hasOwnProperty("error"))
+    } else if (res.success && res.hasOwnProperty("data") && res.data.hasOwnProperty("error"))
       yield Error(res.data.error);
     else
       throw Error("Error with request");

--- a/src/sagas/aws/tagsSaga.js
+++ b/src/sagas/aws/tagsSaga.js
@@ -1,5 +1,5 @@
 import {put, call, all} from 'redux-saga/effects';
-import {getToken, getAWSAccounts, initialTagsCharts, getTagsCharts} from '../misc';
+import {getToken, getAWSAccounts, initialTagsCharts, getTagsCharts, resetTagsDates} from '../misc';
 import API from '../../api';
 import Constants from '../../constants';
 import {getTagsCharts as getTagsChartsLS, setTagsCharts, unsetTagsCharts} from "../../common/localStorage";
@@ -106,7 +106,7 @@ export function* loadTagsChartsSaga() {
     else if (data.hasOwnProperty("charts") && data.hasOwnProperty("dates") && data.hasOwnProperty("filters"))
       yield all([
         put({type: Constants.AWS_TAGS_INSERT_CHARTS, charts: data.charts}),
-        put({type: Constants.AWS_TAGS_INSERT_DATES, dates: data.dates}),
+        put({type: Constants.AWS_TAGS_INSERT_DATES, dates: resetTagsDates(data.dates)}),
         put({type: Constants.AWS_TAGS_INSERT_FILTERS, filters: data.filters})
       ]);
     else

--- a/src/sagas/misc.js
+++ b/src/sagas/misc.js
@@ -63,6 +63,14 @@ const getTagsChartsFromState = (state) => {
   return data;
 };
 
+export const resetTagsDates = (dates) => {
+  Object.keys(dates).forEach((id) => {
+    dates[id].startDate = moment().subtract(30, 'days');
+    dates[id].endDate = moment();
+  });
+  return dates;
+}
+
 export const getTagsCharts = () => {
   return select(getTagsChartsFromState);
 };
@@ -149,8 +157,8 @@ export const initialTagsCharts = () => {
   let dates = {};
   Object.keys(charts).forEach((id) => {
     dates[id] = {
-      startDate: moment().subtract(1, 'month').startOf('month'),
-      endDate: moment().subtract(1, 'month').endOf('month')
+      startDate: moment().subtract(30, 'days'),
+      endDate: moment()
     };
   });
   let filters = {};


### PR DESCRIPTION
- Tags timerange are now reseted on refresh (Last 30 days), keeping the timerange was confusing.
- "Name" or "name" tag key is now selected by default (default was keys[0] which most of the time was quite empty)
- Sub accounts are now sorted alphabetically and not by account Id
- Fixed the events charts (they were reversed because of an API update)
- Fix the account status badge (green even with no bills locations)