### PR TITLE
Add origin to differentiate tagbot/trackit user

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,15 +1,15 @@
 import { call } from './misc.js';
 
 export const login = (email, password, awsToken) => {
-  return call('/user/login', 'POST', {email, password, awsToken});
+  return call('/user/login', 'POST', {email, password, awsToken, origin: "trackit"});
 };
 
 export const register = (email, password, awsToken) => {
-  return call('/user', 'POST', {email, password, awsToken});
+  return call('/user', 'POST', {email, password, awsToken, origin: "trackit"});
 };
 
 export const recoverPassword = (email) => {
-  return call('/user/password/forgotten', 'POST', {email});
+  return call('/user/password/forgotten', 'POST', {email, origin: "trackit"});
 };
 
 export const renewPassword = (id, password, token) => {

--- a/src/api/aws/accounts.js
+++ b/src/api/aws/accounts.js
@@ -45,7 +45,7 @@ export const getAccountViewer = (accountID, token) => {
 };
 
 export const addAccountViewer = (accountID, email, permissionLevel, token) => {
-  return call(`/user/share?account-id=${accountID}`, 'POST', {email, permissionLevel}, token);
+  return call(`/user/share?account-id=${accountID}`, 'POST', {email, permissionLevel, origin: "trackit"}, token);
 };
 
 export const editAccountViewer = (sharedID, permissionLevel, token) => {


### PR DESCRIPTION
Some changes are made on the trackit api to differentiate tagbot/trackit users.
Tagbot account will not be able to login into trackit and vice versa.
This distinction will be made thanks to 'origin' parameters.

Waiting for trackit API - branch feat/tagbot-diff-db